### PR TITLE
Remove orphan CSS classes and unused theme variables from modern nav

### DIFF
--- a/src/styles/modern-nav.css
+++ b/src/styles/modern-nav.css
@@ -41,8 +41,6 @@
 :root {
   --modern-panel-width: 380px;
   --modern-nav-height: 56px;
-  --modern-search-height: 52px;
-  --font-modern-display: 'Raleway', 'Segoe UI', system-ui, sans-serif;
 }
 
 /* ── ModernNavBar ── */
@@ -107,10 +105,6 @@
 
 /* ── HomeScreen ── */
 .modern-home { }
-.modern-home__count {
-  font-size: var(--text-xs); color: var(--color-muted); background: var(--color-surface-raised);
-  padding: var(--space-1) var(--space-3); border-radius: var(--radius-pill); font-weight: 700;
-}
 .modern-home__grid {
   padding: var(--space-4) var(--space-6);
   display: grid;
@@ -173,7 +167,7 @@
 .modern-search-result-row:hover { border-color: var(--color-accent); box-shadow: var(--shadow-pane); }
 .modern-search-result-row__type { font-size: var(--text-xs); font-weight: 700; text-transform: uppercase; letter-spacing: 0.06em; display: block; margin-bottom: var(--space-1); }
 .modern-search-result-row__type--cat     { color: var(--color-accent); }
-.modern-search-result-row__type--sub     { color: var(--color-tag-prayer); }
+.modern-search-result-row__type--sub     { color: var(--color-accent); }
 .modern-search-result-row__type--teaching { color: var(--color-tag-parable); }
 .modern-search-result-row__title { font-size: var(--text-sm); color: var(--color-ink); line-height: 1.45; }
 .modern-search-result-row__crumb { font-size: var(--text-xs); color: var(--color-muted); margin-top: var(--space-1); display: block; }
@@ -384,9 +378,7 @@ mark { background: var(--color-accent-light); color: var(--color-accent); border
 .modern-scripture-chip:hover { background: var(--color-accent); color: white; }
 
 .modern-tag { font-size: var(--text-xs); font-weight: 700; padding: var(--space-1) var(--space-2); border-radius: var(--radius-pill); }
-.modern-tag--parable { color: var(--color-tag-prayer);   background: var(--color-tag-prayer-bg); }
-.modern-tag--promise  { color: var(--color-tag-parable); background: var(--color-tag-parable-bg); }
-.modern-tag--woe      { color: #7B3F00; background: #FFF0E0; }
+.modern-tag--parable { color: var(--color-tag-parable); background: var(--color-tag-parable-bg); }
 
 /* ── TeachingDetail ── */
 .modern-teaching-detail { background: var(--color-bg); min-height: calc(100dvh - 108px); }

--- a/src/styles/themes/theme-classic.css
+++ b/src/styles/themes/theme-classic.css
@@ -3,7 +3,6 @@
   --color-bg: #faf9f6;
   --color-surface: #ffffff;
   --color-surface-raised: #f5f3ef;
-  --color-row-alt: #f5f5f5;
   --color-border: #e0dbd0;
   --color-ink: #2c2a24;
   --color-muted: #6b6459;
@@ -16,21 +15,15 @@
   /* Authority — navy */
   --color-authority: #1b2a40;
   --color-authority-fg: #ffffff;
-  --color-authority-muted: #2e4166;
 
   /* Tag colors */
-  --color-tag-faith: #6b4f1a;
-  --color-tag-faith-bg: #fef3d0;
-  --color-tag-prayer: #1a3f6b;
-  --color-tag-prayer-bg: #ddeeff;
-  --color-tag-love: #6b1a2a;
-  --color-tag-love-bg: #fde8ec;
   --color-tag-parable: #2a5c3f;
   --color-tag-parable-bg: #d4f0e0;
 
   /* Typography */
   --font-display: 'Playfair Display', Georgia, 'Times New Roman', serif;
   --font-body: 'Source Sans 3', 'Segoe UI', system-ui, sans-serif;
+  --font-modern-display: 'Raleway', 'Segoe UI', system-ui, sans-serif;
 
   /* Font sizes */
   --text-xs: 0.75rem;
@@ -51,7 +44,6 @@
   --space-8: 2rem;
   --space-10: 2.5rem;
   --space-12: 3rem;
-  --space-16: 4rem;
 
   /* Radii */
   --radius-sm: 3px;
@@ -68,5 +60,4 @@
   --sidebar-width: 270px;
   --header-height: 56px;
   --filter-bar-height: 52px;
-  --content-max-width: 860px;
 }


### PR DESCRIPTION
- Remove .modern-home__count (defined in CSS, never applied in JSX)
- Remove --modern-search-height variable (defined but never referenced)
- Move --font-modern-display to theme-classic.css with all other design tokens
- Remove --color-tag-faith, --color-tag-prayer, --color-tag-love and their
  -bg counterparts — only parable is a valid tag, all others are dead code
- Remove .modern-tag--promise and .modern-tag--woe CSS rules
- Fix .modern-tag--parable to use --color-tag-parable/parable-bg (was
  incorrectly referencing prayer colors)
- Fix .modern-search-result-row__type--sub to use --color-accent instead
  of the now-removed --color-tag-prayer
- Remove --color-row-alt, --color-authority-muted, --space-16,
  --content-max-width (defined but never referenced anywhere)

https://claude.ai/code/session_01PGNQMkVkuVaVoTTJTcLToE