### PR TITLE
fix(mobile): category TOC item separators and text centering

### DIFF
--- a/src/styles/modern-nav.css
+++ b/src/styles/modern-nav.css
@@ -223,7 +223,18 @@
     text-align: center;
     font-size: var(--text-lg);
     border-left: none;
-    border-bottom: 1px solid var(--color-border);
+    border-bottom: none;
+    position: relative;
+  }
+  .modern-cat-toc__item::after {
+    content: '';
+    position: absolute;
+    bottom: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 40%;
+    height: 1px;
+    background: var(--color-border);
   }
   .modern-cat-toc__item:hover { background: none; }
   .modern-cat-toc__item--active { border-left: none; }

--- a/src/styles/modern-nav.css
+++ b/src/styles/modern-nav.css
@@ -236,6 +236,7 @@
     height: 1px;
     background: var(--color-border);
   }
+  .modern-cat-toc__item:last-child::after { display: none; }
   .modern-cat-toc__item:hover { background: none; }
   .modern-cat-toc__item--active { border-left: none; }
 }

--- a/src/styles/modern-nav.css
+++ b/src/styles/modern-nav.css
@@ -219,8 +219,14 @@
   font-weight: 700;
 }
 @media (max-width: 767px) {
-  .modern-cat-toc__item { text-align: center; font-size: var(--text-lg); }
-  .modern-cat-toc__item:hover { background: none; border-left-color: transparent; }
+  .modern-cat-toc__item {
+    text-align: center;
+    font-size: var(--text-lg);
+    border-left: none;
+    border-bottom: 1px solid var(--color-border);
+  }
+  .modern-cat-toc__item:hover { background: none; }
+  .modern-cat-toc__item--active { border-left: none; }
 }
 
 /* ── HomeScreen (card grid — retained for search fallback render path) ── */


### PR DESCRIPTION
Add a subtle border-bottom (#e0dbd0) between each category nav item on
mobile so they read as distinct list items. Remove the 3px transparent
border-left that was causing the centered text to appear offset to the right.

https://claude.ai/code/session_01E5nMYsn9sn9CK8Ygp1oEJ3