### PR TITLE
Implement full-text search with MiniSearch library

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "lucide-react": "^0.441.0",
+        "minisearch": "^7.2.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-router-dom": "^6.26.2",
@@ -4750,6 +4751,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "lucide-react": "^0.441.0",
+    "minisearch": "^7.2.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-router-dom": "^6.26.2",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,6 +10,7 @@ import FilterBar from './components/FilterBar/FilterBar.jsx'
 import CatalogOptimizer from './components/CatalogOptimizer/CatalogOptimizer.jsx'
 import { loadTeachings } from './data/loader.js'
 import { buildReverseIndex } from './data/reverseIndex.js'
+import { buildSearchIndex } from './utils/search.js'
 import useStore from './store.js'
 import { useLocalPreference } from './hooks/useLocalPreference.js'
 import ModernApp from './components/ModernApp/ModernApp.jsx'
@@ -49,6 +50,7 @@ function AppRoutes() {
     loadTeachings()
       .then(({ categories, meta }) => {
         buildReverseIndex(categories)
+        buildSearchIndex(categories)
         setData({ categories, meta })
       })
       .catch((err) => setDataError(err.message))

--- a/src/components/ModernApp/CategoryBrowser.jsx
+++ b/src/components/ModernApp/CategoryBrowser.jsx
@@ -2,12 +2,8 @@ import { useMemo } from 'react'
 import { Menu } from 'lucide-react'
 import { useIsMobile } from '../../hooks/useBreakpoint.js'
 import { NT_BOOK_ABBR_ORDER } from '../../utils/bookOrder.js'
-
-function highlight(text, query) {
-  if (!query) return text
-  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>')
-}
+import { useSearch } from '../../hooks/useSearch.js'
+import { resolveResult, highlightTerms } from '../../utils/search.js'
 
 function TeachingCard({ teaching, onNavigate, onOpenBible }) {
   return (
@@ -30,22 +26,26 @@ function TeachingCard({ teaching, onNavigate, onOpenBible }) {
   )
 }
 
-function InCategorySearchResults({ cat, tabIndex, searchQuery, onNavigate }) {
-  const query = searchQuery.trim().toLowerCase()
+function InCategorySearchResults({ cat, searchQuery, onNavigate }) {
+  const { results, isSearching } = useSearch(searchQuery, { categoryId: cat?.id })
+
   const subcatResults = []
   const teachingResults = []
+  const subcatSet = new Set()
 
-  if (cat && query) {
-    cat.subcategories.forEach((sub, subIdx) => {
-      if (sub.title.toLowerCase().includes(query)) {
-        subcatResults.push({ sub, subIdx })
+  if (isSearching) {
+    for (const result of results) {
+      const { sub, teaching, tabIndex: subIdx } = resolveResult(result, [cat])
+      if (!sub || !teaching) continue
+
+      const matchedFields = Object.values(result.match).flat()
+      if (matchedFields.includes('subcategoryTitle') && !subcatSet.has(sub.id)) {
+        subcatSet.add(sub.id)
+        subcatResults.push({ sub, subIdx, result })
+      } else {
+        teachingResults.push({ sub, subIdx, teaching, result })
       }
-      sub.teachings.forEach(t => {
-        if (t.text.toLowerCase().includes(query)) {
-          teachingResults.push({ sub, subIdx, teaching: t })
-        }
-      })
-    })
+    }
   }
 
   const hasResults = subcatResults.length > 0 || teachingResults.length > 0
@@ -58,7 +58,7 @@ function InCategorySearchResults({ cat, tabIndex, searchQuery, onNavigate }) {
       {subcatResults.length > 0 && (
         <>
           <div className="modern-search-results__label">Sections</div>
-          {subcatResults.map(({ sub, subIdx }) => (
+          {subcatResults.map(({ sub, subIdx, result }) => (
             <button
               key={sub.id}
               className="modern-search-result-row"
@@ -67,7 +67,7 @@ function InCategorySearchResults({ cat, tabIndex, searchQuery, onNavigate }) {
               <span className="modern-search-result-row__type modern-search-result-row__type--sub">Section</span>
               <div
                 className="modern-search-result-row__title"
-                dangerouslySetInnerHTML={{ __html: highlight(sub.title, query) }}
+                dangerouslySetInnerHTML={{ __html: highlightTerms(sub.title, result.terms) }}
               />
             </button>
           ))}
@@ -76,7 +76,7 @@ function InCategorySearchResults({ cat, tabIndex, searchQuery, onNavigate }) {
       {teachingResults.length > 0 && (
         <>
           <div className="modern-search-results__label">Teachings</div>
-          {teachingResults.map(({ sub, subIdx, teaching }) => (
+          {teachingResults.map(({ sub, subIdx, teaching, result }) => (
             <button
               key={teaching.id}
               className="modern-search-result-row"
@@ -85,7 +85,7 @@ function InCategorySearchResults({ cat, tabIndex, searchQuery, onNavigate }) {
               <span className="modern-search-result-row__type modern-search-result-row__type--teaching">Teaching</span>
               <div
                 className="modern-search-result-row__title"
-                dangerouslySetInnerHTML={{ __html: highlight(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), query) }}
+                dangerouslySetInnerHTML={{ __html: highlightTerms(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), result.terms) }}
               />
               <span className="modern-search-result-row__crumb">{sub.title}</span>
             </button>
@@ -203,7 +203,6 @@ export default function CategoryBrowser({
       ) : (
         <InCategorySearchResults
           cat={cat}
-          tabIndex={tabIndex}
           searchQuery={searchQuery}
           onNavigate={(subcatIdx, teachingId) => {
             onTabChange(subcatIdx)

--- a/src/components/ModernApp/CategoryBrowser.jsx
+++ b/src/components/ModernApp/CategoryBrowser.jsx
@@ -29,11 +29,13 @@ function TeachingCard({ teaching, onNavigate, onOpenBible }) {
 function InCategorySearchResults({ cat, searchQuery, onNavigate }) {
   const { results, isSearching } = useSearch(searchQuery, { categoryId: cat?.id })
 
-  const subcatResults = []
-  const teachingResults = []
-  const subcatSet = new Set()
+  const { subcatResults, teachingResults } = useMemo(() => {
+    const subcatResults = []
+    const teachingResults = []
+    const subcatSet = new Set()
 
-  if (isSearching) {
+    if (!isSearching) return { subcatResults, teachingResults }
+
     for (const result of results) {
       const { sub, teaching, tabIndex: subIdx } = resolveResult(result, [cat])
       if (!sub || !teaching) continue
@@ -46,7 +48,8 @@ function InCategorySearchResults({ cat, searchQuery, onNavigate }) {
         teachingResults.push({ sub, subIdx, teaching, result })
       }
     }
-  }
+    return { subcatResults, teachingResults }
+  }, [results, cat, isSearching])
 
   const hasResults = subcatResults.length > 0 || teachingResults.length > 0
 
@@ -65,10 +68,9 @@ function InCategorySearchResults({ cat, searchQuery, onNavigate }) {
               onClick={() => onNavigate(subIdx, null)}
             >
               <span className="modern-search-result-row__type modern-search-result-row__type--sub">Section</span>
-              <div
-                className="modern-search-result-row__title"
-                dangerouslySetInnerHTML={{ __html: highlightTerms(sub.title, result.terms) }}
-              />
+              <div className="modern-search-result-row__title">
+                {highlightTerms(sub.title, result.terms)}
+              </div>
             </button>
           ))}
         </>
@@ -83,10 +85,9 @@ function InCategorySearchResults({ cat, searchQuery, onNavigate }) {
               onClick={() => onNavigate(subIdx, teaching.id)}
             >
               <span className="modern-search-result-row__type modern-search-result-row__type--teaching">Teaching</span>
-              <div
-                className="modern-search-result-row__title"
-                dangerouslySetInnerHTML={{ __html: highlightTerms(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), result.terms) }}
-              />
+              <div className="modern-search-result-row__title">
+                {highlightTerms(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), result.terms)}
+              </div>
               <span className="modern-search-result-row__crumb">{sub.title}</span>
             </button>
           ))}
@@ -164,7 +165,7 @@ export default function CategoryBrowser({
         )}
       </div>
 
-      {!searchQuery ? (
+      {!searchQuery.trim() ? (
         <div className="modern-browser-body">
           {!isMobile && (
             <nav className="modern-subcat-toc">

--- a/src/components/ModernApp/HomeScreen.jsx
+++ b/src/components/ModernApp/HomeScreen.jsx
@@ -48,7 +48,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
     [results, categories, isSearching]
   )
 
-  if (searchQuery) {
+  if (searchQuery.trim()) {
     const hasResults = catResults.length > 0 || subcatResults.length > 0 || teachingResults.length > 0
     return (
       <div className="modern-search-results">
@@ -65,10 +65,9 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 onClick={() => { onNavigateToCategory(cat.id); onClearSearch() }}
               >
                 <span className="modern-search-result-row__type modern-search-result-row__type--cat">Category</span>
-                <div
-                  className="modern-search-result-row__title"
-                  dangerouslySetInnerHTML={{ __html: highlightTerms(cat.title, result.terms) }}
-                />
+                <div className="modern-search-result-row__title">
+                  {highlightTerms(cat.title, result.terms)}
+                </div>
               </button>
             ))}
           </>
@@ -83,10 +82,9 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 onClick={() => { onNavigateToCategory(cat.id, tabIndex); onClearSearch() }}
               >
                 <span className="modern-search-result-row__type modern-search-result-row__type--sub">Section</span>
-                <div
-                  className="modern-search-result-row__title"
-                  dangerouslySetInnerHTML={{ __html: highlightTerms(sub.title, result.terms) }}
-                />
+                <div className="modern-search-result-row__title">
+                  {highlightTerms(sub.title, result.terms)}
+                </div>
                 <span className="modern-search-result-row__crumb">{cat.title}</span>
               </button>
             ))}
@@ -102,10 +100,9 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 onClick={() => { onNavigateToTeaching(teaching.id, cat.id, tabIndex); onClearSearch() }}
               >
                 <span className="modern-search-result-row__type modern-search-result-row__type--teaching">Teaching</span>
-                <div
-                  className="modern-search-result-row__title"
-                  dangerouslySetInnerHTML={{ __html: highlightTerms(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), result.terms) }}
-                />
+                <div className="modern-search-result-row__title">
+                  {highlightTerms(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), result.terms)}
+                </div>
                 <span className="modern-search-result-row__crumb">{cat.title} › {sub.title}</span>
               </button>
             ))}

--- a/src/components/ModernApp/HomeScreen.jsx
+++ b/src/components/ModernApp/HomeScreen.jsx
@@ -1,9 +1,32 @@
 import { useMemo } from 'react'
+import { useSearch } from '../../hooks/useSearch.js'
+import { resolveResult, highlightTerms } from '../../utils/search.js'
 
-function highlight(text, query) {
-  if (!query) return text
-  const escaped = query.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  return text.replace(new RegExp(`(${escaped})`, 'gi'), '<mark>$1</mark>')
+function groupResults(results, categories) {
+  const catSet = new Set()
+  const subcatSet = new Set()
+  const catResults = []
+  const subcatResults = []
+  const teachingResults = []
+
+  for (const result of results) {
+    const { cat, sub, teaching, tabIndex } = resolveResult(result, categories)
+    if (!cat || !sub || !teaching) continue
+
+    const matchedFields = Object.values(result.match).flat()
+
+    if (matchedFields.includes('categoryTitle') && !catSet.has(cat.id)) {
+      catSet.add(cat.id)
+      catResults.push({ cat, result })
+    } else if (matchedFields.includes('subcategoryTitle') && !subcatSet.has(sub.id)) {
+      subcatSet.add(sub.id)
+      subcatResults.push({ cat, sub, tabIndex, result })
+    } else {
+      teachingResults.push({ cat, sub, tabIndex, teaching, result })
+    }
+  }
+
+  return { catResults, subcatResults, teachingResults }
 }
 
 export default function HomeScreen({ categories, searchQuery, onNavigateToCategory, onNavigateToTeaching, onClearSearch }) {
@@ -18,26 +41,12 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
     return count / maxTeachingCount
   }
 
-  const query = searchQuery.trim().toLowerCase()
-  const catResults = query ? categories.filter(c => c.title.toLowerCase().includes(query)) : []
-  const subcatResults = []
-  const teachingResults = []
+  const { results, isSearching } = useSearch(searchQuery)
 
-  if (query) {
-    categories.forEach((cat) => {
-      const catMatched = catResults.includes(cat)
-      cat.subcategories.forEach((sub, subIdx) => {
-        if (!catMatched && sub.title.toLowerCase().includes(query)) {
-          subcatResults.push({ cat, sub, tabIndex: subIdx })
-        }
-        sub.teachings.forEach(t => {
-          if (t.text.toLowerCase().includes(query)) {
-            teachingResults.push({ cat, sub, tabIndex: subIdx, teaching: t })
-          }
-        })
-      })
-    })
-  }
+  const { catResults, subcatResults, teachingResults } = useMemo(
+    () => isSearching ? groupResults(results, categories) : { catResults: [], subcatResults: [], teachingResults: [] },
+    [results, categories, isSearching]
+  )
 
   if (searchQuery) {
     const hasResults = catResults.length > 0 || subcatResults.length > 0 || teachingResults.length > 0
@@ -49,7 +58,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
         {catResults.length > 0 && (
           <>
             <div className="modern-search-results__label">Categories</div>
-            {catResults.map(cat => (
+            {catResults.map(({ cat, result }) => (
               <button
                 key={cat.id}
                 className="modern-search-result-row"
@@ -58,7 +67,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 <span className="modern-search-result-row__type modern-search-result-row__type--cat">Category</span>
                 <div
                   className="modern-search-result-row__title"
-                  dangerouslySetInnerHTML={{ __html: highlight(cat.title, query) }}
+                  dangerouslySetInnerHTML={{ __html: highlightTerms(cat.title, result.terms) }}
                 />
               </button>
             ))}
@@ -67,7 +76,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
         {subcatResults.length > 0 && (
           <>
             <div className="modern-search-results__label">Subcategories</div>
-            {subcatResults.map(({ cat, sub, tabIndex }) => (
+            {subcatResults.map(({ cat, sub, tabIndex, result }) => (
               <button
                 key={`${cat.id}-${sub.id}`}
                 className="modern-search-result-row"
@@ -76,7 +85,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 <span className="modern-search-result-row__type modern-search-result-row__type--sub">Section</span>
                 <div
                   className="modern-search-result-row__title"
-                  dangerouslySetInnerHTML={{ __html: highlight(sub.title, query) }}
+                  dangerouslySetInnerHTML={{ __html: highlightTerms(sub.title, result.terms) }}
                 />
                 <span className="modern-search-result-row__crumb">{cat.title}</span>
               </button>
@@ -86,7 +95,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
         {teachingResults.length > 0 && (
           <>
             <div className="modern-search-results__label">Teachings</div>
-            {teachingResults.map(({ cat, sub, tabIndex, teaching }) => (
+            {teachingResults.map(({ cat, sub, tabIndex, teaching, result }) => (
               <button
                 key={teaching.id}
                 className="modern-search-result-row"
@@ -95,7 +104,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 <span className="modern-search-result-row__type modern-search-result-row__type--teaching">Teaching</span>
                 <div
                   className="modern-search-result-row__title"
-                  dangerouslySetInnerHTML={{ __html: highlight(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), query) }}
+                  dangerouslySetInnerHTML={{ __html: highlightTerms(teaching.text.slice(0, 120) + (teaching.text.length > 120 ? '…' : ''), result.terms) }}
                 />
                 <span className="modern-search-result-row__crumb">{cat.title} › {sub.title}</span>
               </button>

--- a/src/components/ModernApp/ModernApp.jsx
+++ b/src/components/ModernApp/ModernApp.jsx
@@ -30,12 +30,18 @@ export default function ModernApp() {
   const [currentTeaching, setCurrentTeaching] = useState(null)
   const [activeBookFilter, setActiveBookFilter] = useState(null)
   const [searchQuery, setSearchQuery] = useState('')
+  const [lastSearchQuery, setLastSearchQuery] = useState('')
   const [bibleRef, setBibleRef] = useState(null)
   const [bibleOpen, setBibleOpen] = useState(false)
   const [biblePinned, setBiblePinned] = useState(false)
   const [tocVisible, setTocVisible] = useState(true)
 
   function showScreen(entry) {
+    if (entry.screen === 'home') {
+      setLastSearchQuery('')
+    } else if (searchQuery.trim()) {
+      setLastSearchQuery(searchQuery)
+    }
     setSearchQuery('')
     if (entry.screen === 'category') {
       if (entry.catId !== currentCatId) setActiveBookFilter(null)
@@ -56,6 +62,16 @@ export default function ModernApp() {
     }
   }
 
+  function backToResults() {
+    if (!lastSearchQuery) return
+    setCurrentCatId(null)
+    setCurrentTabIndex(0)
+    setCurrentTeaching(null)
+    setTocVisible(true)
+    setSearchQuery(lastSearchQuery)
+    setLastSearchQuery('')
+  }
+
   const currentScreen = currentTeaching !== null ? 'teaching' : currentCatId !== null ? 'category' : 'home'
 
   return (
@@ -74,8 +90,11 @@ export default function ModernApp() {
           currentCatId={currentCatId}
           categories={categories}
           searchQuery={searchQuery}
+          lastSearchQuery={lastSearchQuery}
+          onBackToResults={backToResults}
           onSearchChange={(q) => {
             setSearchQuery(q)
+            if (q.trim()) setLastSearchQuery('')
             if (isMobile && currentScreen === 'home') setTocVisible(!q)
           }}
         />
@@ -111,7 +130,7 @@ export default function ModernApp() {
                     <h2 className="modern-home-placeholder__heading">Explore the Words of Jesus</h2>
                     <p className="modern-home-placeholder__body">
                       Choose a <strong>Topic</strong> to dive into a theme,
-                      or use the <Search size={14} className="modern-home-placeholder__inline-icon" aria-hidden="true" /> <strong>search bar</strong> above to find teachings by keyword.
+                      or use the <Search size={14} className="modern-home-placeholder__inline-icon" aria-hidden="true" /> <strong>search bar</strong> above.
                     </p>
                   </div>
                 )

--- a/src/components/ModernApp/ModernSearchBar.jsx
+++ b/src/components/ModernApp/ModernSearchBar.jsx
@@ -1,6 +1,14 @@
-import { Search } from 'lucide-react'
+import { ArrowLeft, Search } from 'lucide-react'
 
-export default function ModernSearchBar({ disabled, currentCatId, categories, searchQuery, onSearchChange }) {
+export default function ModernSearchBar({
+  disabled,
+  currentCatId,
+  categories,
+  searchQuery,
+  onSearchChange,
+  lastSearchQuery,
+  onBackToResults,
+}) {
   const currentCat = categories.find(c => c.id === currentCatId) ?? null
   const placeholder = currentCatId
     ? `Search in ${currentCat?.title ?? ''}…`
@@ -8,6 +16,16 @@ export default function ModernSearchBar({ disabled, currentCatId, categories, se
 
   return (
     <div className={`modern-search-bar${disabled ? ' modern-search-bar--disabled' : ''}`}>
+      {lastSearchQuery && (
+        <button
+          type="button"
+          className="modern-search-bar__back-to-results"
+          onClick={onBackToResults}
+        >
+          <ArrowLeft size={14} aria-hidden="true" />
+          <span>Back to results for &ldquo;{lastSearchQuery}&rdquo;</span>
+        </button>
+      )}
       <div className="modern-search-bar__wrap">
         <Search className="modern-search-bar__icon" size={15} aria-hidden="true" />
         <input

--- a/src/hooks/useSearch.js
+++ b/src/hooks/useSearch.js
@@ -1,0 +1,22 @@
+import { useMemo } from 'react'
+import { search } from '../utils/search.js'
+
+/**
+ * @param {string} rawQuery
+ * @param {{ categoryId?: string }} [options]
+ */
+export function useSearch(rawQuery, options = {}) {
+  const { categoryId } = options
+
+  const { results, phraseFilter } = useMemo(() => {
+    if (!rawQuery.trim()) return { results: [], phraseFilter: null }
+    return search(rawQuery, { categoryId })
+  }, [rawQuery, categoryId])
+
+  return {
+    results,
+    phraseFilter,
+    hasResults: results.length > 0,
+    isSearching: rawQuery.trim().length > 0,
+  }
+}

--- a/src/styles/modern-nav.css
+++ b/src/styles/modern-nav.css
@@ -169,6 +169,17 @@
   border: none;
 }
 .modern-search-bar--disabled .modern-search-bar__wrap { opacity: 0.5; pointer-events: none; }
+.modern-search-bar__back-to-results {
+  display: inline-flex; align-items: center; gap: var(--space-1);
+  margin-bottom: var(--space-2); padding: var(--space-1) var(--space-2);
+  border: 1px solid var(--color-accent-mid); border-radius: var(--radius-sm);
+  background: var(--color-accent-light); color: var(--color-authority);
+  font-family: var(--font-body); font-size: var(--text-xs); font-weight: 600;
+  cursor: pointer; line-height: 1.2; max-width: 100%;
+  transition: background-color 0.15s ease, border-color 0.15s ease;
+}
+.modern-search-bar__back-to-results:hover { background: var(--color-accent); color: #fff; border-color: var(--color-accent); }
+.modern-search-bar__back-to-results > span { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; min-width: 0; }
 
 /* ── CategoryTOC ── */
 .modern-cat-toc {

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -1,0 +1,142 @@
+import MiniSearch from 'minisearch'
+
+const FIELDS = ['text', 'quote', 'categoryTitle', 'subcategoryTitle', 'tagsStr', 'referenceLabels']
+
+const MINISEARCH_CONFIG = {
+  idField: 'docId',
+  fields: FIELDS,
+  storeFields: ['categoryId', 'subcategoryId', ...FIELDS],
+  tokenize: (text) =>
+    text
+      .replace(/['']/g, "'")
+      .replace(/[—–]/g, ' ')
+      .toLowerCase()
+      .split(/[^a-z0-9']+/)
+      .filter(Boolean),
+  processTerm: (term) =>
+    term.replace(/'s$/, 's').replace(/^'+|'+$/g, '') || null,
+}
+
+const DEFAULT_SEARCH_OPTIONS = {
+  boost: {
+    categoryTitle: 3,
+    subcategoryTitle: 2,
+    tagsStr: 1.5,
+    referenceLabels: 1.5,
+    text: 1,
+    quote: 1,
+  },
+  fuzzy: 0.2,
+  prefix: true,
+  combineWith: 'AND',
+}
+
+let _miniSearch = null
+
+export function buildSearchIndex(categories) {
+  if (_miniSearch) return _miniSearch
+
+  const documents = []
+  for (const cat of categories) {
+    for (const sub of cat.subcategories) {
+      for (const teaching of sub.teachings) {
+        documents.push({
+          docId: teaching.id,
+          uid: teaching.uid,
+          categoryId: cat.id,
+          subcategoryId: sub.id,
+          text: teaching.text ?? '',
+          quote: teaching.quote ?? '',
+          tagsStr: teaching.tags.join(' '),
+          referenceLabels: teaching.references
+            .map(r => r.label.replace(/[,:]/g, ' '))
+            .join(' '),
+          categoryTitle: cat.title,
+          subcategoryTitle: sub.title,
+        })
+      }
+    }
+  }
+
+  _miniSearch = new MiniSearch(MINISEARCH_CONFIG)
+  _miniSearch.addAll(documents)
+  return _miniSearch
+}
+
+export function getSearchIndex() {
+  return _miniSearch
+}
+
+/**
+ * @param {string} rawQuery
+ * @param {{ categoryId?: string }} [options]
+ * @returns {{ results: object[], phraseFilter: string|null }}
+ */
+export function search(rawQuery, options = {}) {
+  if (!_miniSearch || !rawQuery.trim()) return { results: [], phraseFilter: null }
+
+  const { categoryId } = options
+
+  const phraseMatch = rawQuery.match(/^"(.+)"$/)
+  const phraseFilter = phraseMatch && phraseMatch[1].trim()
+    ? phraseMatch[1].toLowerCase()
+    : null
+  const queryText = phraseFilter ?? rawQuery.trim()
+
+  const filter = categoryId
+    ? (result) => result.categoryId === categoryId
+    : undefined
+
+  const isPhraseSearch = Boolean(phraseFilter)
+
+  let results = _miniSearch.search(queryText, {
+    ...DEFAULT_SEARCH_OPTIONS,
+    filter,
+    combineWith: 'AND',
+    fuzzy: isPhraseSearch ? false : DEFAULT_SEARCH_OPTIONS.fuzzy,
+    prefix: isPhraseSearch ? false : DEFAULT_SEARCH_OPTIONS.prefix,
+  })
+
+  // Fall back to OR when AND yields nothing (non-phrase queries only)
+  if (results.length === 0 && !isPhraseSearch) {
+    results = _miniSearch.search(queryText, {
+      ...DEFAULT_SEARCH_OPTIONS,
+      filter,
+      combineWith: 'OR',
+    })
+  }
+
+  if (phraseFilter) {
+    results = results.filter(r => {
+      const haystack = FIELDS.map(f => r[f] ?? '').join(' ').toLowerCase()
+      return haystack.includes(phraseFilter)
+    })
+  }
+
+  return { results, phraseFilter }
+}
+
+/**
+ * Maps a MiniSearch result back to { cat, sub, teaching, tabIndex }.
+ * Pass a single-element array [cat] when scoped to one category.
+ */
+export function resolveResult(result, categories) {
+  const cat = categories.find(c => c.id === result.categoryId)
+  if (!cat) return {}
+  const tabIndex = cat.subcategories.findIndex(s => s.id === result.subcategoryId)
+  const sub = tabIndex >= 0 ? cat.subcategories[tabIndex] : null
+  if (!sub) return { cat }
+  const teaching = sub.teachings.find(t => t.id === result.id)
+  return { cat, sub, teaching, tabIndex }
+}
+
+/**
+ * Highlights all matched terms in text. Use result.terms from MiniSearch.
+ */
+export function highlightTerms(text, terms) {
+  if (!terms || terms.length === 0) return text
+  const pattern = terms
+    .map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+    .join('|')
+  return text.replace(new RegExp(`(${pattern})`, 'gi'), '<mark>$1</mark>')
+}

--- a/src/utils/search.js
+++ b/src/utils/search.js
@@ -1,3 +1,4 @@
+import { createElement } from 'react'
 import MiniSearch from 'minisearch'
 
 const FIELDS = ['text', 'quote', 'categoryTitle', 'subcategoryTitle', 'tagsStr', 'referenceLabels']
@@ -26,15 +27,17 @@ const DEFAULT_SEARCH_OPTIONS = {
     text: 1,
     quote: 1,
   },
-  fuzzy: 0.2,
+  // Fuzzy disabled on short terms: 0.2 * 4 chars rounds to 1 edit, 
+  // Require 5+ chars before allowing typos.
+  fuzzy: (term) => (term.length >= 5 ? 0.2 : false),
   prefix: true,
   combineWith: 'AND',
 }
 
 let _miniSearch = null
 
-export function buildSearchIndex(categories) {
-  if (_miniSearch) return _miniSearch
+export function buildSearchIndex(categories, { force = false } = {}) {
+  if (_miniSearch && !force) return _miniSearch
 
   const documents = []
   for (const cat of categories) {
@@ -42,15 +45,12 @@ export function buildSearchIndex(categories) {
       for (const teaching of sub.teachings) {
         documents.push({
           docId: teaching.id,
-          uid: teaching.uid,
           categoryId: cat.id,
           subcategoryId: sub.id,
           text: teaching.text ?? '',
           quote: teaching.quote ?? '',
           tagsStr: teaching.tags.join(' '),
-          referenceLabels: teaching.references
-            .map(r => r.label.replace(/[,:]/g, ' '))
-            .join(' '),
+          referenceLabels: teaching.references.map(r => r.label).join(' '),
           categoryTitle: cat.title,
           subcategoryTitle: sub.title,
         })
@@ -92,7 +92,6 @@ export function search(rawQuery, options = {}) {
   let results = _miniSearch.search(queryText, {
     ...DEFAULT_SEARCH_OPTIONS,
     filter,
-    combineWith: 'AND',
     fuzzy: isPhraseSearch ? false : DEFAULT_SEARCH_OPTIONS.fuzzy,
     prefix: isPhraseSearch ? false : DEFAULT_SEARCH_OPTIONS.prefix,
   })
@@ -131,12 +130,16 @@ export function resolveResult(result, categories) {
 }
 
 /**
- * Highlights all matched terms in text. Use result.terms from MiniSearch.
+ * Highlights all matched terms in text, returning an array of React nodes
+ * (string segments interleaved with <mark> elements). Use result.terms from MiniSearch.
  */
 export function highlightTerms(text, terms) {
   if (!terms || terms.length === 0) return text
   const pattern = terms
     .map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
     .join('|')
-  return text.replace(new RegExp(`(${pattern})`, 'gi'), '<mark>$1</mark>')
+  const regex = new RegExp(`(${pattern})`, 'gi')
+  return text.split(regex).map((part, i) =>
+    i % 2 === 1 ? createElement('mark', { key: i }, part) : part
+  )
 }


### PR DESCRIPTION
## Summary
Replaces the basic substring search implementation with a robust full-text search system powered by MiniSearch. This enables fuzzy matching, prefix search, field-specific boosting, and phrase search capabilities across categories, subcategories, and teachings.

## Key Changes

- **New search utility module** (`src/utils/search.js`):
  - `buildSearchIndex()`: Constructs a MiniSearch index from category data with configurable tokenization and term processing
  - `search()`: Performs full-text queries with fuzzy matching, prefix search, AND/OR fallback logic, and optional category filtering
  - `resolveResult()`: Maps search results back to category/subcategory/teaching objects
  - `highlightTerms()`: Highlights matched terms in text using result metadata

- **New search hook** (`src/hooks/useSearch.js`):
  - `useSearch()`: React hook that wraps the search utility with memoization and optional category scoping

- **Updated HomeScreen component**:
  - Replaced simple substring matching with `useSearch()` hook
  - Implemented `groupResults()` to categorize results by type (category/subcategory/teaching)
  - Uses `result.terms` from MiniSearch for accurate highlighting instead of raw query string

- **Updated CategoryBrowser component**:
  - Integrated `useSearch()` hook for in-category search
  - Removed unused `tabIndex` prop from `InCategorySearchResults`
  - Uses MiniSearch result metadata for highlighting

- **App initialization**:
  - Calls `buildSearchIndex()` on app startup to pre-build the search index

- **Dependencies**:
  - Added `minisearch` (^7.2.0) as a production dependency

## Notable Implementation Details

- Search index is built once and cached in module state (`_miniSearch`)
- Tokenization handles smart quotes, dashes, and apostrophes
- Field-specific boost weights prioritize category/subcategory titles over content
- Phrase search (quoted queries) disables fuzzy matching and prefix search for exact matching
- AND query mode falls back to OR when no results found (non-phrase queries only)
- Search results include matched field information for intelligent result grouping and highlighting

https://claude.ai/code/session_01RPHZLM5sWyvAPJYZGzQPDH