### PR TITLE
Rebrand terminology and update home placeholder UI

### DIFF
--- a/public/icons/chat_bub_512.svg
+++ b/public/icons/chat_bub_512.svg
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 256 256">
+
+  <defs>
+    <linearGradient id="bgRL" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f7f1e3"></stop>
+      <stop offset="100%" stop-color="#ede4cc"></stop>
+    </linearGradient>
+    <linearGradient id="bubbleRed" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#c92b32"></stop>
+      <stop offset="100%" stop-color="#a01e25"></stop>
+    </linearGradient>
+  </defs>
+
+  <g transform="translate(128 134)">
+    <path d="M -78 -56 Q -78 -68 -66 -68 L 66 -68 Q 78 -68 78 -56 L 78 30 Q 78 42 66 42 L 12 42 L -6 64 L -6 42 L -66 42 Q -78 42 -78 30 Z" fill="url(#bubbleRed)" stroke="#8f1a20" stroke-width="2" stroke-linejoin="round"></path>
+    <g stroke="#f7f1e3" stroke-width="7" stroke-linecap="round">
+      <line x1="-54" y1="-40" x2="54" y2="-40"></line>
+      <line x1="-54" y1="-14" x2="38" y2="-14"></line>
+      <line x1="-54" y1="12" x2="48" y2="12"></line>
+    </g>
+  </g>
+
+</svg>

--- a/src/components/AboutPanel/AboutContent.jsx
+++ b/src/components/AboutPanel/AboutContent.jsx
@@ -15,7 +15,6 @@ export default function AboutContent({ onShowVersion }) {
 
       {/* ── Hero ── */}
       <div className="about-hero">
-        <span className="about-hero__cross" aria-hidden="true">✝</span>
         <h1 className="about-hero__title">Jesus Says</h1>
       </div>
 

--- a/src/components/ModernApp/CategoryBrowser.jsx
+++ b/src/components/ModernApp/CategoryBrowser.jsx
@@ -60,14 +60,14 @@ function InCategorySearchResults({ cat, searchQuery, onNavigate }) {
       )}
       {subcatResults.length > 0 && (
         <>
-          <div className="modern-search-results__label">Sections</div>
+          <div className="modern-search-results__label">Topics</div>
           {subcatResults.map(({ sub, subIdx, result }) => (
             <button
               key={sub.id}
               className="modern-search-result-row"
               onClick={() => onNavigate(subIdx, null)}
             >
-              <span className="modern-search-result-row__type modern-search-result-row__type--sub">Section</span>
+              <span className="modern-search-result-row__type modern-search-result-row__type--sub">Topic</span>
               <div className="modern-search-result-row__title">
                 {highlightTerms(sub.title, result.terms)}
               </div>
@@ -140,7 +140,7 @@ export default function CategoryBrowser({
     <div className="modern-category-browser">
       <div className="modern-cat-hero">
         <button className="modern-view-topics-btn" onClick={isMobile ? onGoHome : onShowToc}>
-          <Menu size={16} /> View Topics
+          <Menu size={16} /> View Themes
         </button>
         <h2 className="modern-cat-hero__title">{cat?.title}</h2>
 
@@ -187,7 +187,7 @@ export default function CategoryBrowser({
           <div className="modern-teachings-list">
             {visibleTeachings.length === 0 ? (
               <div className="modern-empty-state">
-                No teachings from {activeBookFilter} in this section.
+                No teachings from {activeBookFilter} in this topic.
               </div>
             ) : (
               visibleTeachings.map(teaching => (

--- a/src/components/ModernApp/CategoryBrowser.jsx
+++ b/src/components/ModernApp/CategoryBrowser.jsx
@@ -169,7 +169,7 @@ export default function CategoryBrowser({
         <div className="modern-browser-body">
           {!isMobile && (
             <nav className="modern-subcat-toc">
-              <div className="modern-subcat-toc__header">Discourses</div>
+              <div className="modern-subcat-toc__header">Topics</div>
               <div className="modern-subcat-toc__inner">
                 {cat?.subcategories.map((sub, idx) => (
                   <button

--- a/src/components/ModernApp/CategoryTOC.jsx
+++ b/src/components/ModernApp/CategoryTOC.jsx
@@ -4,7 +4,7 @@ export default function CategoryTOC({ categories, currentCatId, onNavigateToCate
   return (
     <div className="modern-cat-toc">
       <button className="modern-cat-toc__label" onClick={onGoHome}>
-        <Home size={13} /> Topics
+        <Home size={13} /> Themes
       </button>
       {categories.map(cat => (
         <button

--- a/src/components/ModernApp/HomeScreen.jsx
+++ b/src/components/ModernApp/HomeScreen.jsx
@@ -81,7 +81,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
                 className="modern-search-result-row"
                 onClick={() => { onNavigateToCategory(cat.id, tabIndex); onClearSearch() }}
               >
-                <span className="modern-search-result-row__type modern-search-result-row__type--sub">Section</span>
+                <span className="modern-search-result-row__type modern-search-result-row__type--sub">Topic</span>
                 <div className="modern-search-result-row__title">
                   {highlightTerms(sub.title, result.terms)}
                 </div>

--- a/src/components/ModernApp/HomeScreen.jsx
+++ b/src/components/ModernApp/HomeScreen.jsx
@@ -57,14 +57,14 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
         )}
         {catResults.length > 0 && (
           <>
-            <div className="modern-search-results__label">Categories</div>
+            <div className="modern-search-results__label">Themes</div>
             {catResults.map(({ cat, result }) => (
               <button
                 key={cat.id}
                 className="modern-search-result-row"
                 onClick={() => { onNavigateToCategory(cat.id); onClearSearch() }}
               >
-                <span className="modern-search-result-row__type modern-search-result-row__type--cat">Category</span>
+                <span className="modern-search-result-row__type modern-search-result-row__type--cat">Theme</span>
                 <div className="modern-search-result-row__title">
                   {highlightTerms(cat.title, result.terms)}
                 </div>
@@ -74,7 +74,7 @@ export default function HomeScreen({ categories, searchQuery, onNavigateToCatego
         )}
         {subcatResults.length > 0 && (
           <>
-            <div className="modern-search-results__label">Subcategories</div>
+            <div className="modern-search-results__label">Topics</div>
             {subcatResults.map(({ cat, sub, tabIndex, result }) => (
               <button
                 key={`${cat.id}-${sub.id}`}

--- a/src/components/ModernApp/ModernApp.jsx
+++ b/src/components/ModernApp/ModernApp.jsx
@@ -1,5 +1,5 @@
 import { useState } from 'react'
-import { BookOpen, Search } from 'lucide-react'
+import { Search } from 'lucide-react'
 import useStore from '../../store.js'
 import ModernNavBar from './ModernNavBar.jsx'
 import ModernSearchBar from './ModernSearchBar.jsx'
@@ -126,11 +126,11 @@ export default function ModernApp() {
               ) : (
                 !isMobile && (
                   <div className="modern-home-placeholder">
-                    <BookOpen className="modern-home-placeholder__icon" aria-hidden="true" />
-                    <h2 className="modern-home-placeholder__heading">Explore the Words of Jesus</h2>
+                    <img src="/JesusSays/icons/chat_bub_512.svg" className="modern-home-placeholder__icon" alt="" aria-hidden="true" />
+                    <h2 className="modern-home-placeholder__heading">Explore the Teachings of Jesus Christ</h2>
                     <p className="modern-home-placeholder__body">
-                      Choose a <strong>Topic</strong> to dive into a theme,
-                      or use the <Search size={14} className="modern-home-placeholder__inline-icon" aria-hidden="true" /> <strong>search bar</strong> above.
+                      Choose a <strong>Theme</strong> to dive into the <strong>Topics</strong>,
+                      <br />or use the <Search size={14} className="modern-home-placeholder__inline-icon" aria-hidden="true" /> <strong>Search</strong> above.
                     </p>
                   </div>
                 )

--- a/src/styles/base.css
+++ b/src/styles/base.css
@@ -838,7 +838,7 @@ a:hover {
 
 /* ── Hero section ── */
 .about-hero {
-  background: var(--color-authority);
+  background: var(--color-authority-about);
   color: var(--color-authority-fg);
   padding: var(--space-10) var(--space-6) var(--space-8);
   text-align: center;
@@ -1006,7 +1006,7 @@ a:hover {
 }
 
 .about-version-view__header {
-  background: var(--color-authority);
+  background: var(--color-authority-about);
   color: var(--color-authority-fg);
   padding: var(--space-10) var(--space-5) var(--space-5);
   display: flex;

--- a/src/styles/modern-nav.css
+++ b/src/styles/modern-nav.css
@@ -77,11 +77,7 @@
   gap: var(--space-4);
 }
 .modern-home-placeholder__icon {
-  width: 52px;
-  height: 52px;
-  color: var(--color-accent);
-  opacity: 0.7;
-  margin-bottom: var(--space-2);
+  height: 80px;
 }
 .modern-home-placeholder__heading {
   font-family: var(--font-display);

--- a/src/styles/themes/theme-classic.css
+++ b/src/styles/themes/theme-classic.css
@@ -14,6 +14,7 @@
 
   /* Authority — navy */
   --color-authority: #1b2a40;
+  --color-authority-about: #283d5d;
   --color-authority-fg: #ffffff;
 
   /* Tag colors */


### PR DESCRIPTION
This PR updates the application's terminology and improves the home screen placeholder design to better reflect the content hierarchy and enhance user experience.

## Summary
Updated UI labels and terminology throughout the application to use more intuitive naming conventions ("Themes" for categories, "Topics" for subcategories), replaced the home placeholder icon with a custom chat bubble SVG, and refined related styling.

## Key Changes
- **Terminology updates**: Renamed "Categories" → "Themes", "Subcategories"/"Sections" → "Topics", and "Discourses" → "Topics" across search results and navigation components
- **Home placeholder redesign**: Replaced `BookOpen` icon from lucide-react with a custom red chat bubble SVG (`chat_bub_512.svg`) and updated the placeholder text to "Explore the Teachings of Jesus Christ"
- **Icon styling**: Adjusted CSS for the new placeholder icon (removed color/opacity properties, set fixed height of 80px)
- **About section**: Removed decorative cross symbol from the about hero section and adjusted the hero background color to use a new `--color-authority-about` variable for better visual distinction
- **Navigation updates**: Updated button labels ("View Topics" → "View Themes", "Topics" → "Themes" in category TOC)
- **Unused import cleanup**: Removed unused `BookOpen` import from ModernApp.jsx

## Implementation Details
- Added new CSS custom property `--color-authority-about` (#283d5d) for the about section background
- The chat bubble icon is now an image element instead of an icon component, allowing for custom branding
- All terminology changes maintain consistency across HomeScreen, CategoryBrowser, and CategoryTOC components

https://claude.ai/code/session_01QgHjZs6pvC6v4NKfUsdPLV