### PR TITLE
Switch mobile layout trigger to orientation-aware breakpoint

### DIFF
--- a/src/components/ModernApp/ModernApp.jsx
+++ b/src/components/ModernApp/ModernApp.jsx
@@ -18,7 +18,11 @@ const BIBLE_LAST_BOOK_KEY = 'bibleLastBook'
 const BIBLE_LAST_CH_KEY   = 'bibleLastChapter'
 
 function isDesktopViewport() {
-  return typeof window !== 'undefined' && window.innerWidth >= 768
+  if (typeof window === 'undefined') return true
+  const width = window.innerWidth
+  if (width < 768) return false
+  if (width < 1024 && window.matchMedia('(orientation: portrait)').matches) return false
+  return true
 }
 
 function findTeachingById(teachingId, categories) {

--- a/src/hooks/useBreakpoint.js
+++ b/src/hooks/useBreakpoint.js
@@ -42,5 +42,16 @@ export function useBreakpoint() {
 
 export function useIsMobile() {
   const bp = useBreakpoint()
-  return bp === 'xs' || bp === 'sm'
+  const [isPortrait, setIsPortrait] = useState(() =>
+    typeof window !== 'undefined' ? window.matchMedia('(orientation: portrait)').matches : false
+  )
+
+  useEffect(() => {
+    const mq = window.matchMedia('(orientation: portrait)')
+    const handler = (e) => setIsPortrait(e.matches)
+    mq.addEventListener('change', handler)
+    return () => mq.removeEventListener('change', handler)
+  }, [])
+
+  return bp === 'xs' || bp === 'sm' || (bp === 'md' && isPortrait)
 }


### PR DESCRIPTION
iPad portrait (768–1023px width) now activates the mobile layout via
matchMedia orientation check rather than a fixed width threshold.
useIsMobile() reacts to rotation in real time; isDesktopViewport()
applies the same logic for initial state hydration.

https://claude.ai/code/session_01KJmAD3hCu6d5G45T1BunPP