### PR TITLE
feat: offline Bible caching via IndexedDB with auto-download

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jesus-says",
-  "version": "0.1.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jesus-says",
-      "version": "0.1.0",
+      "version": "1.0.1",
       "dependencies": {
         "lucide-react": "^0.441.0",
         "minisearch": "^7.2.0",

--- a/src/components/ModernApp/BibleViewer/BibleBrowser.jsx
+++ b/src/components/ModernApp/BibleViewer/BibleBrowser.jsx
@@ -194,12 +194,8 @@ export default function BibleBrowser({ bibleRef }) {
       })
     } else {
       // Reset and load the new chapter
-      initialLoadDone.current = false
       setSegments([])
-      setTimeout(() => {
-        initialLoadDone.current = true
-        loadAndAppend(bibleRef.bookAbbr, bibleRef.chapter)
-      }, 0)
+      loadAndAppend(bibleRef.bookAbbr, bibleRef.chapter)
     }
   }, [bibleRef])
 

--- a/src/components/ModernApp/BibleViewer/BibleBrowser.jsx
+++ b/src/components/ModernApp/BibleViewer/BibleBrowser.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react'
 import useStore from '../../../store.js'
 import { bibleApi } from '../../../data/bibleApi.js'
+import { OfflineOnlyError } from '../../../data/BibleOfflineStore.js'
 import { NT_BOOKS } from '../../../utils/bookOrder.js'
 import BibleContent from './BibleContent.jsx'
 
@@ -76,7 +77,10 @@ function ChapterSegment({ seg, prevSeg, highlightVerses }) {
       >
         Chapter {seg.chapterNum}
       </div>
-      <BibleContent verses={seg.verses} highlightVerses={highlightVerses} />
+      {seg.loadError
+        ? <div className="bible-offline-warning">{seg.loadError}</div>
+        : <BibleContent verses={seg.verses} highlightVerses={highlightVerses} />
+      }
     </div>
   )
 }
@@ -102,6 +106,19 @@ export default function BibleBrowser({ bibleRef }) {
   const initialChapter = bibleRef?.chapter ?? (bibleBrowseBook ? bibleBrowseChapter : 1)
   const highlightVerses = bibleRef?.ranges ?? []
 
+  function buildErrorSeg(bookAbbr, chapterNum, err) {
+    const book = NT_BOOKS_MAP[bookAbbr]
+    const isOffline = err instanceof OfflineOnlyError
+    return {
+      id: `${bookAbbr}-${chapterNum}`,
+      bookAbbr,
+      bookName: book?.fullName ?? bookAbbr,
+      chapterNum,
+      verses: null,
+      loadError: isOffline ? err.message : 'Failed to load chapter.',
+    }
+  }
+
   async function loadAndPrepend(bookAbbr, chapterNum) {
     setLoadingPrev(true)
     try {
@@ -112,6 +129,9 @@ export default function BibleBrowser({ bibleRef }) {
       requestAnimationFrame(() => {
         document.getElementById(`bible-ch-${seg.id}`)?.scrollIntoView({ behavior: 'instant', block: 'start' })
       })
+    } catch (err) {
+      const seg = buildErrorSeg(bookAbbr, chapterNum, err)
+      setSegments(prev => prev.some(s => s.id === seg.id) ? prev : [seg, ...prev])
     } finally {
       setLoadingPrev(false)
     }
@@ -129,6 +149,9 @@ export default function BibleBrowser({ bibleRef }) {
           document.getElementById(`bible-ch-${seg.id}`)?.scrollIntoView({ behavior: 'instant', block: 'start' })
         })
       }
+    } catch (err) {
+      const seg = buildErrorSeg(bookAbbr, chapterNum, err)
+      setSegments(prev => prev.some(s => s.id === seg.id) ? prev : [...prev, seg])
     } finally {
       setLoadingNext(false)
     }

--- a/src/components/ModernApp/BibleViewer/BibleDownloadBanner.jsx
+++ b/src/components/ModernApp/BibleViewer/BibleDownloadBanner.jsx
@@ -1,0 +1,27 @@
+import useStore from '../../../store.js'
+import { ENABLE_OFFLINE_BIBLE } from '../../../featureFlags.js'
+
+export default function BibleDownloadBanner() {
+  const bibleTranslation = useStore(s => s.bibleTranslation)
+  const status = useStore(s => s.bibleDownloadStatus[bibleTranslation])
+
+  if (!ENABLE_OFFLINE_BIBLE) return null
+  if (status.state !== 'downloading' && status.state !== 'checking') return null
+
+  const pct = Math.round(status.progress * 100)
+
+  return (
+    <div className="bible-download-banner">
+      <span className="bible-download-banner__text">
+        {status.state === 'checking'
+          ? `Checking ${bibleTranslation}…`
+          : `Caching ${bibleTranslation} — ${pct}%`}
+      </span>
+      {status.state === 'downloading' && (
+        <div className="bible-download-progress">
+          <div className="bible-download-progress__fill" style={{ width: `${pct}%` }} />
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/ModernApp/BibleViewer/BibleDrawer.jsx
+++ b/src/components/ModernApp/BibleViewer/BibleDrawer.jsx
@@ -4,6 +4,7 @@ import TranslationPicker from './TranslationPicker.jsx'
 import BookPicker from './BookPicker.jsx'
 import ChapterPicker from './ChapterPicker.jsx'
 import BibleBrowser from './BibleBrowser.jsx'
+import BibleDownloadBanner from './BibleDownloadBanner.jsx'
 import '../../../styles/bible-viewer.css'
 
 export default function BibleDrawer({ bibleRef, open, onClose }) {
@@ -126,6 +127,7 @@ export default function BibleDrawer({ bibleRef, open, onClose }) {
             <button className="modern-drawer-close" onClick={handleClose} aria-label="Close">✕</button>
           </div>
           <div className="modern-drawer-body">
+            <BibleDownloadBanner />
             {everOpened && <BibleBrowser bibleRef={activeRef} />}
           </div>
         </div>

--- a/src/components/ModernApp/BibleViewer/BiblePanel.jsx
+++ b/src/components/ModernApp/BibleViewer/BiblePanel.jsx
@@ -4,6 +4,7 @@ import TranslationPicker from './TranslationPicker.jsx'
 import BookPicker from './BookPicker.jsx'
 import ChapterPicker from './ChapterPicker.jsx'
 import BibleBrowser from './BibleBrowser.jsx'
+import BibleDownloadBanner from './BibleDownloadBanner.jsx'
 import '../../../styles/bible-viewer.css'
 
 const PANEL_MIN_WIDTH = 380
@@ -131,6 +132,7 @@ export default function BiblePanel({ bibleRef, open, pinned, onClose, onTogglePi
         </div>
       </div>
       <div className="modern-panel-body">
+        <BibleDownloadBanner />
         {everOpened && <BibleBrowser bibleRef={bibleRef} />}
       </div>
     </div>

--- a/src/components/ModernApp/BibleViewer/BibleViewer.jsx
+++ b/src/components/ModernApp/BibleViewer/BibleViewer.jsx
@@ -1,9 +1,71 @@
+import { useEffect } from 'react'
+import useStore from '../../../store.js'
 import { useIsMobile } from '../../../hooks/useBreakpoint.js'
 import BiblePanel from './BiblePanel.jsx'
 import BibleDrawer from './BibleDrawer.jsx'
+import { bibleApi } from '../../../data/bibleApi.js'
+import { bibleOfflineStore } from '../../../data/BibleOfflineStore.js'
+import { ENABLE_OFFLINE_BIBLE } from '../../../featureFlags.js'
 
-export default function BibleViewer({ bibleRef, open, pinned, onClose, onTogglePin, onReopen /* unimplemented */, onWidthChange }) {
+export default function BibleViewer({ bibleRef, open, pinned, onClose, onTogglePin, onReopen, onWidthChange }) {
   const isMobile = useIsMobile()
+  const categories          = useStore(s => s.categories)
+  const bibleTranslation    = useStore(s => s.bibleTranslation)
+  const bibleDownloadStatus = useStore(s => s.bibleDownloadStatus)
+  const setBibleDownloadStatus = useStore(s => s.setBibleDownloadStatus)
+
+  useEffect(() => {
+    if (!ENABLE_OFFLINE_BIBLE || !open || !categories.length) return
+    const { state } = bibleDownloadStatus[bibleTranslation]
+    if (state === 'downloading' || state === 'complete' || state === 'checking') return
+    triggerCatalogDownload(bibleTranslation)
+  }, [open, bibleTranslation, categories.length])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function triggerCatalogDownload(translation) {
+    setBibleDownloadStatus(translation, { state: 'checking' })
+
+    const catalogBooks = new Set()
+    for (const cat of categories) {
+      for (const subcat of cat.subcategories ?? []) {
+        for (const teaching of subcat.teachings ?? []) {
+          for (const ref of teaching.references ?? []) {
+            if (ref.bookAbbr) catalogBooks.add(ref.bookAbbr)
+          }
+        }
+      }
+    }
+    const bookList = [...catalogBooks]
+
+    try {
+      const downloadedBooks = await bibleOfflineStore.getDownloadedBooks(translation)
+      const needed = bookList.filter(b => !downloadedBooks.includes(b))
+
+      if (needed.length === 0) {
+        setBibleDownloadStatus(translation, { state: 'complete', downloadedBooks: bookList, progress: 1 })
+        return
+      }
+
+      setBibleDownloadStatus(translation, { state: 'downloading', progress: 0 })
+
+      await bibleOfflineStore.downloadBooks(
+        translation,
+        needed,
+        (t, b, c) => bibleApi.fetchRawChapter(t, b, c),
+        ({ done, total }) => {
+          setBibleDownloadStatus(translation, { progress: total > 0 ? done / total : 0 })
+        }
+      )
+
+      setBibleDownloadStatus(translation, {
+        state: 'complete',
+        downloadedBooks: [...downloadedBooks, ...needed],
+        progress: 1,
+      })
+    } catch (err) {
+      setBibleDownloadStatus(translation, { state: 'error', error: err.message })
+    }
+  }
+
   return isMobile
     ? <BibleDrawer bibleRef={bibleRef} open={open} onClose={onClose} onReopen={onReopen} />
     : <BiblePanel  bibleRef={bibleRef} open={open} pinned={pinned} onClose={onClose} onTogglePin={onTogglePin} onWidthChange={onWidthChange} />

--- a/src/components/ModernApp/BibleViewer/BibleViewer.jsx
+++ b/src/components/ModernApp/BibleViewer/BibleViewer.jsx
@@ -17,7 +17,7 @@ export default function BibleViewer({ bibleRef, open, pinned, onClose, onToggleP
   useEffect(() => {
     if (!ENABLE_OFFLINE_BIBLE || !open || !categories.length) return
     const { state } = bibleDownloadStatus[bibleTranslation]
-    if (state === 'downloading' || state === 'complete' || state === 'checking') return
+    if (state === 'downloading' || state === 'complete' || state === 'checking' || state === 'error') return
     triggerCatalogDownload(bibleTranslation)
   }, [open, bibleTranslation, categories.length])  // eslint-disable-line react-hooks/exhaustive-deps
 
@@ -56,10 +56,12 @@ export default function BibleViewer({ bibleRef, open, pinned, onClose, onToggleP
         }
       )
 
+      const bytes = await bibleOfflineStore.getStorageBytes(translation)
       setBibleDownloadStatus(translation, {
         state: 'complete',
         downloadedBooks: [...downloadedBooks, ...needed],
         progress: 1,
+        bytes,
       })
     } catch (err) {
       setBibleDownloadStatus(translation, { state: 'error', error: err.message })

--- a/src/components/SettingsMenu/DownloadManager.jsx
+++ b/src/components/SettingsMenu/DownloadManager.jsx
@@ -1,0 +1,127 @@
+import { useEffect } from 'react'
+import useStore from '../../store.js'
+import { bibleOfflineStore } from '../../data/BibleOfflineStore.js'
+import { bibleApi } from '../../data/bibleApi.js'
+import { ENABLE_OFFLINE_BIBLE } from '../../featureFlags.js'
+
+const TRANSLATIONS = ['KJV', 'NKJV', 'NIV']
+
+function formatBytes(bytes) {
+  if (!bytes) return ''
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+function getCatalogBooks(categories) {
+  const books = new Set()
+  for (const cat of categories) {
+    for (const subcat of cat.subcategories ?? []) {
+      for (const teaching of subcat.teachings ?? []) {
+        for (const ref of teaching.references ?? []) {
+          if (ref.bookAbbr) books.add(ref.bookAbbr)
+        }
+      }
+    }
+  }
+  return [...books]
+}
+
+export default function DownloadManager() {
+  const categories          = useStore(s => s.categories)
+  const bibleDownloadStatus = useStore(s => s.bibleDownloadStatus)
+  const setBibleDownloadStatus = useStore(s => s.setBibleDownloadStatus)
+
+  // On first render, check IDB for already-downloaded translations and sync Zustand state.
+  useEffect(() => {
+    if (!categories.length) return
+    const bookList = getCatalogBooks(categories)
+    TRANSLATIONS.forEach(async (t) => {
+      if (bibleDownloadStatus[t].state !== 'idle') return
+      try {
+        const downloaded = await bibleOfflineStore.getDownloadedBooks(t)
+        if (!downloaded.length) return
+        const hasAllCatalog = bookList.every(b => downloaded.includes(b))
+        const bytes = hasAllCatalog ? await bibleOfflineStore.getStorageBytes(t) : 0
+        setBibleDownloadStatus(t, {
+          state: hasAllCatalog ? 'complete' : 'idle',
+          downloadedBooks: downloaded,
+          bytes,
+        })
+      } catch {
+        // IDB unavailable — leave state as idle
+      }
+    })
+  }, [categories.length])  // eslint-disable-line react-hooks/exhaustive-deps
+
+  async function handleDownload(translation) {
+    const bookList = getCatalogBooks(categories)
+    setBibleDownloadStatus(translation, { state: 'downloading', progress: 0, error: null })
+    try {
+      const downloadedBooks = await bibleOfflineStore.getDownloadedBooks(translation)
+      const needed = bookList.filter(b => !downloadedBooks.includes(b))
+      if (needed.length === 0) {
+        const bytes = await bibleOfflineStore.getStorageBytes(translation)
+        setBibleDownloadStatus(translation, { state: 'complete', downloadedBooks: bookList, bytes, progress: 1 })
+        return
+      }
+      await bibleOfflineStore.downloadBooks(
+        translation,
+        needed,
+        (t, b, c) => bibleApi.fetchRawChapter(t, b, c),
+        ({ done, total }) => setBibleDownloadStatus(translation, { progress: total > 0 ? done / total : 0 })
+      )
+      const bytes = await bibleOfflineStore.getStorageBytes(translation)
+      setBibleDownloadStatus(translation, {
+        state: 'complete',
+        downloadedBooks: [...downloadedBooks, ...needed],
+        bytes,
+        progress: 1,
+      })
+    } catch (err) {
+      setBibleDownloadStatus(translation, { state: 'error', error: err.message })
+    }
+  }
+
+  async function handleDelete(translation) {
+    try {
+      await bibleOfflineStore.deleteTranslation(translation)
+    } catch {
+      // Continue even if IDB delete fails
+    }
+    setBibleDownloadStatus(translation, { state: 'idle', progress: 0, downloadedBooks: [], bytes: 0, error: null })
+  }
+
+  return (
+    <div className="settings-menu__section">
+      <div className="settings-menu__section-label">Bible Storage</div>
+      {TRANSLATIONS.map(t => {
+        const s = bibleDownloadStatus[t]
+        const isActive = s.state === 'downloading' || s.state === 'checking'
+        return (
+          <div key={t} className="download-manager__row">
+            <span className="download-manager__name">{t}</span>
+            <span className="download-manager__info">
+              {s.state === 'complete' && s.bytes > 0 && formatBytes(s.bytes)}
+              {isActive && `${Math.round(s.progress * 100)}%`}
+              {s.state === 'error' && <span className="download-manager__error">Error</span>}
+            </span>
+            {s.state === 'idle' && (
+              <button className="download-manager__btn" onClick={() => handleDownload(t)}>Download</button>
+            )}
+            {isActive && (
+              <span className="download-manager__spinner" aria-label="Downloading" />
+            )}
+            {s.state === 'complete' && (
+              <button className="download-manager__btn download-manager__btn--delete" onClick={() => handleDelete(t)}>Delete</button>
+            )}
+            {s.state === 'error' && (
+              <button className="download-manager__btn" onClick={() => handleDownload(t)}>Retry</button>
+            )}
+          </div>
+        )
+      })}
+    </div>
+  )
+}
+
+DownloadManager.enabled = ENABLE_OFFLINE_BIBLE

--- a/src/components/SettingsMenu/DownloadManager.jsx
+++ b/src/components/SettingsMenu/DownloadManager.jsx
@@ -85,6 +85,7 @@ export default function DownloadManager() {
   async function handleDelete(translation) {
     try {
       await bibleOfflineStore.deleteTranslation(translation)
+      bibleApi.clearCache(translation)
     } catch {
       // Continue even if IDB delete fails
     }
@@ -124,4 +125,3 @@ export default function DownloadManager() {
   )
 }
 
-DownloadManager.enabled = ENABLE_OFFLINE_BIBLE

--- a/src/components/SettingsMenu/SettingsMenu.css
+++ b/src/components/SettingsMenu/SettingsMenu.css
@@ -54,3 +54,38 @@
   font-size: var(--text-sm); color: var(--color-muted);
   margin-left: var(--space-1); white-space: nowrap;
 }
+
+/* ── Download Manager ── */
+.download-manager__row {
+  display: flex; align-items: center; gap: var(--space-2);
+  padding: var(--space-1) 0;
+}
+.download-manager__name {
+  font-size: var(--text-sm); font-weight: 600; color: var(--color-ink);
+  min-width: 44px;
+}
+.download-manager__info {
+  flex: 1; font-size: var(--text-xs); color: var(--color-muted);
+}
+.download-manager__error { color: var(--color-error); }
+.download-manager__btn {
+  flex-shrink: 0; padding: 3px 10px;
+  font-size: var(--text-xs); font-weight: 600;
+  border: 1px solid var(--color-accent-mid); border-radius: var(--radius-sm);
+  background: var(--color-accent-light); color: var(--color-accent);
+  cursor: pointer; transition: background 0.12s;
+}
+.download-manager__btn:hover { background: #ede3c8; }
+.download-manager__btn--delete {
+  border-color: var(--color-border); background: transparent; color: var(--color-muted);
+}
+.download-manager__btn--delete:hover { background: var(--color-surface-raised); color: var(--color-ink); }
+.download-manager__spinner {
+  flex-shrink: 0; display: inline-block;
+  width: 12px; height: 12px;
+  border: 2px solid var(--color-border);
+  border-top-color: var(--color-accent-mid);
+  border-radius: 50%;
+  animation: dm-spin 0.7s linear infinite;
+}
+@keyframes dm-spin { to { transform: rotate(360deg); } }

--- a/src/components/SettingsMenu/SettingsMenu.jsx
+++ b/src/components/SettingsMenu/SettingsMenu.jsx
@@ -3,7 +3,8 @@ import { createPortal } from 'react-dom'
 import { Settings } from 'lucide-react'
 import { useNavigate } from 'react-router-dom'
 import useStore from '../../store.js'
-import { ENABLE_ABOUT_PAGE } from '../../featureFlags.js'
+import { ENABLE_ABOUT_PAGE, ENABLE_OFFLINE_BIBLE } from '../../featureFlags.js'
+import DownloadManager from './DownloadManager.jsx'
 import './SettingsMenu.css'
 
 export default function SettingsMenu() {
@@ -70,6 +71,12 @@ export default function SettingsMenu() {
                 <span className="settings-menu__size-label">{bibleFontSize}px</span>
               </div>
             </div>
+            {ENABLE_OFFLINE_BIBLE && (
+              <>
+                <div className="settings-menu__divider" />
+                <DownloadManager />
+              </>
+            )}
             {import.meta.env.DEV && (
               <>
                 <div className="settings-menu__divider" />

--- a/src/data/ApiBibleClient.js
+++ b/src/data/ApiBibleClient.js
@@ -1,4 +1,6 @@
 import { BibleService } from './BibleService.js'
+import { ENABLE_OFFLINE_BIBLE, ENABLE_API_FALLBACK } from '../featureFlags.js'
+import { bibleOfflineStore, OfflineOnlyError } from './BibleOfflineStore.js'
 
 const BASE_URL = 'https://rest.api.bible/v1'
 
@@ -29,26 +31,56 @@ export class ApiBibleClient extends BibleService {
     const cacheKey = `${translationKey}-${bookAbbr}-${chapterNum}`
     if (this.cache.has(cacheKey)) return this.cache.get(cacheKey)
 
-    const bibleId = BIBLE_IDS[translationKey]
-    const osisId  = OSIS_IDS[bookAbbr]
-    if (!bibleId) return Promise.reject(new Error(`Unknown translationKey: ${translationKey}`))
-    if (!osisId)  return Promise.reject(new Error(`Unknown bookAbbr: ${bookAbbr}`))
-    const chapterId = `${osisId}.${chapterNum}`
-    const url       = `${BASE_URL}/bibles/${bibleId}/chapters/${chapterId}` +
-                      `?content-type=html&include-notes=false&include-titles=true` +
-                      `&include-chapter-numbers=false&include-verse-numbers=true&include-verse-spans=true`
-
     // Cache the promise immediately so concurrent calls share one in-flight request.
     // On failure, evict so the next call can retry.
-    const promise = fetch(url, { headers: { 'api-key': this.apiKey } })
-      .then(res => {
-        if (!res.ok) throw new Error(`api.bible error: ${res.status} for ${chapterId} (${translationKey})`)
-        return res.json()
-      })
-      .then(json => this._parseHtml(json.data.content, translationKey))
+    const promise = this._resolveChapter(translationKey, bookAbbr, chapterNum)
       .catch(err => { this.cache.delete(cacheKey); throw err })
     this.cache.set(cacheKey, promise)
     return promise
+  }
+
+  async _resolveChapter(translationKey, bookAbbr, chapterNum) {
+    if (!ENABLE_OFFLINE_BIBLE) {
+      const html = await this._fetchRaw(translationKey, bookAbbr, chapterNum)
+      return this._parseHtml(html, translationKey)
+    }
+
+    const available = await bibleOfflineStore.isAvailable()
+    if (!available) {
+      if (!ENABLE_API_FALLBACK) throw new OfflineOnlyError()
+      const html = await this._fetchRaw(translationKey, bookAbbr, chapterNum)
+      return this._parseHtml(html, translationKey)
+    }
+
+    const cachedHtml = await bibleOfflineStore.getChapter(translationKey, bookAbbr, chapterNum)
+    if (cachedHtml !== null) {
+      return this._parseHtml(cachedHtml, translationKey)
+    }
+
+    // Not in IDB — fetch from API and cache for future use
+    const html = await this._fetchRaw(translationKey, bookAbbr, chapterNum)
+    await bibleOfflineStore.saveChapter(translationKey, bookAbbr, chapterNum, html)
+    return this._parseHtml(html, translationKey)
+  }
+
+  async _fetchRaw(translationKey, bookAbbr, chapterNum) {
+    const bibleId = BIBLE_IDS[translationKey]
+    const osisId  = OSIS_IDS[bookAbbr]
+    if (!bibleId) throw new Error(`Unknown translationKey: ${translationKey}`)
+    if (!osisId)  throw new Error(`Unknown bookAbbr: ${bookAbbr}`)
+    const chapterId = `${osisId}.${chapterNum}`
+    const url = `${BASE_URL}/bibles/${bibleId}/chapters/${chapterId}` +
+                `?content-type=html&include-notes=false&include-titles=true` +
+                `&include-chapter-numbers=false&include-verse-numbers=true&include-verse-spans=true`
+    const res = await fetch(url, { headers: { 'api-key': this.apiKey } })
+    if (!res.ok) throw new Error(`api.bible error: ${res.status} for ${chapterId} (${translationKey})`)
+    const json = await res.json()
+    return json.data.content
+  }
+
+  // Used by BibleOfflineStore bulk-download to fetch raw HTML without the offline layer.
+  fetchRawChapter(translationKey, bookAbbr, chapterNum) {
+    return this._fetchRaw(translationKey, bookAbbr, chapterNum)
   }
 
   async getPassage(translationKey, reference) {

--- a/src/data/ApiBibleClient.js
+++ b/src/data/ApiBibleClient.js
@@ -83,6 +83,12 @@ export class ApiBibleClient extends BibleService {
     return this._fetchRaw(translationKey, bookAbbr, chapterNum)
   }
 
+  clearCache(translationKey) {
+    for (const key of [...this.cache.keys()]) {
+      if (key.startsWith(`${translationKey}-`)) this.cache.delete(key)
+    }
+  }
+
   async getPassage(translationKey, reference) {
     const bibleId = BIBLE_IDS[translationKey]
     if (!bibleId) throw new Error(`Unknown translationKey: ${translationKey}`)

--- a/src/data/BibleOfflineStore.js
+++ b/src/data/BibleOfflineStore.js
@@ -1,0 +1,200 @@
+import { NT_BOOKS } from '../utils/bookOrder.js'
+
+const DB_NAME = 'jesus-says-bible'
+const DB_VERSION = 1
+const STORE_CHAPTERS = 'chapters'
+const STORE_META = 'download_meta'
+const CONCURRENCY = 3
+const MAX_RETRIES = 3
+
+export class OfflineOnlyError extends Error {
+  constructor() {
+    super('Bible text unavailable. Offline storage is not accessible in this browser.')
+    this.name = 'OfflineOnlyError'
+  }
+}
+
+class BibleOfflineStore {
+  constructor() {
+    this._dbPromise = null
+  }
+
+  _openDB() {
+    if (this._dbPromise) return this._dbPromise
+    this._dbPromise = new Promise((resolve, reject) => {
+      const req = indexedDB.open(DB_NAME, DB_VERSION)
+      req.onupgradeneeded = (e) => {
+        const db = e.target.result
+        if (!db.objectStoreNames.contains(STORE_CHAPTERS)) {
+          db.createObjectStore(STORE_CHAPTERS)
+        }
+        if (!db.objectStoreNames.contains(STORE_META)) {
+          db.createObjectStore(STORE_META)
+        }
+      }
+      req.onsuccess = (e) => resolve(e.target.result)
+      req.onerror = () => {
+        this._dbPromise = null
+        reject(req.error)
+      }
+    })
+    return this._dbPromise
+  }
+
+  async isAvailable() {
+    try {
+      await this._openDB()
+      return true
+    } catch {
+      return false
+    }
+  }
+
+  _key(translation, book, chapter) {
+    return `${translation}:${book}:${chapter}`
+  }
+
+  async getChapter(translation, book, chapter) {
+    const db = await this._openDB()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_CHAPTERS, 'readonly')
+      const req = tx.objectStore(STORE_CHAPTERS).get(this._key(translation, book, chapter))
+      req.onsuccess = () => resolve(req.result ?? null)
+      req.onerror = () => reject(req.error)
+    })
+  }
+
+  async saveChapter(translation, book, chapter, html) {
+    const db = await this._openDB()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_CHAPTERS, 'readwrite')
+      const req = tx.objectStore(STORE_CHAPTERS).put(html, this._key(translation, book, chapter))
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+      req.onerror = () => reject(req.error)
+    })
+  }
+
+  async getDownloadedBooks(translation) {
+    const db = await this._openDB()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_META, 'readonly')
+      const req = tx.objectStore(STORE_META).get(translation)
+      req.onsuccess = () => resolve(req.result?.downloadedBooks ?? [])
+      req.onerror = () => reject(req.error)
+    })
+  }
+
+  async _saveMetaBook(translation, bookAbbr) {
+    const db = await this._openDB()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_META, 'readwrite')
+      const store = tx.objectStore(STORE_META)
+      const req = store.get(translation)
+      req.onsuccess = () => {
+        const meta = req.result ?? { downloadedBooks: [] }
+        if (!meta.downloadedBooks.includes(bookAbbr)) {
+          meta.downloadedBooks.push(bookAbbr)
+        }
+        const putReq = store.put(meta, translation)
+        putReq.onerror = () => reject(putReq.error)
+      }
+      req.onerror = () => reject(req.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  }
+
+  async getStorageBytes(translation) {
+    const db = await this._openDB()
+    return new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_CHAPTERS, 'readonly')
+      const store = tx.objectStore(STORE_CHAPTERS)
+      const prefix = `${translation}:`
+      const range = IDBKeyRange.bound(prefix, prefix + '￿')
+      let bytes = 0
+      const req = store.openCursor(range)
+      req.onsuccess = (e) => {
+        const cursor = e.target.result
+        if (cursor) {
+          bytes += (cursor.value?.length ?? 0) * 2
+          cursor.continue()
+        }
+      }
+      req.onerror = () => reject(req.error)
+      tx.oncomplete = () => resolve(bytes)
+      tx.onerror = () => reject(tx.error)
+    })
+  }
+
+  async deleteTranslation(translation) {
+    const db = await this._openDB()
+    const prefix = `${translation}:`
+    const range = IDBKeyRange.bound(prefix, prefix + '￿')
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_CHAPTERS, 'readwrite')
+      const req = tx.objectStore(STORE_CHAPTERS).openCursor(range)
+      req.onsuccess = (e) => {
+        const cursor = e.target.result
+        if (cursor) { cursor.delete(); cursor.continue() }
+      }
+      req.onerror = () => reject(req.error)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+    await new Promise((resolve, reject) => {
+      const tx = db.transaction(STORE_META, 'readwrite')
+      tx.objectStore(STORE_META).delete(translation)
+      tx.oncomplete = () => resolve()
+      tx.onerror = () => reject(tx.error)
+    })
+  }
+
+  async _fetchWithRetry(fetchRaw, translation, bookAbbr, chapterNum) {
+    let delay = 1000
+    for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+      try {
+        return await fetchRaw(translation, bookAbbr, chapterNum)
+      } catch (err) {
+        if (attempt === MAX_RETRIES - 1) throw err
+        await new Promise(r => setTimeout(r, delay))
+        delay *= 2
+      }
+    }
+  }
+
+  async downloadBooks(translation, bookAbbrArray, fetchRaw, onProgress) {
+    const total = bookAbbrArray.reduce((sum, abbr) => {
+      const book = NT_BOOKS.find(b => b.abbr === abbr)
+      return sum + (book?.chapters ?? 0)
+    }, 0)
+    let done = 0
+
+    for (const abbr of bookAbbrArray) {
+      const book = NT_BOOKS.find(b => b.abbr === abbr)
+      if (!book) continue
+
+      const chapterNums = Array.from({ length: book.chapters }, (_, i) => i + 1)
+
+      for (let i = 0; i < chapterNums.length; i += CONCURRENCY) {
+        const batch = chapterNums.slice(i, i + CONCURRENCY)
+        await Promise.all(batch.map(async (chapterNum) => {
+          const existing = await this.getChapter(translation, abbr, chapterNum)
+          if (existing !== null) {
+            done++
+            onProgress?.({ done, total })
+            return
+          }
+          const html = await this._fetchWithRetry(fetchRaw, translation, abbr, chapterNum)
+          await this.saveChapter(translation, abbr, chapterNum, html)
+          done++
+          onProgress?.({ done, total })
+        }))
+      }
+
+      await this._saveMetaBook(translation, abbr)
+    }
+  }
+}
+
+export const bibleOfflineStore = new BibleOfflineStore()

--- a/src/data/BibleOfflineStore.js
+++ b/src/data/BibleOfflineStore.js
@@ -34,7 +34,6 @@ class BibleOfflineStore {
       }
       req.onsuccess = (e) => resolve(e.target.result)
       req.onerror = () => {
-        this._dbPromise = null
         reject(req.error)
       }
     })

--- a/src/featureFlags.js
+++ b/src/featureFlags.js
@@ -1,5 +1,13 @@
 // Feature flags for Jesus Says app
-// Reserved for future feature flags.
 
 // ENABLE_ABOUT_PAGE: About panel with app info, creator bio, and version details.
 export const ENABLE_ABOUT_PAGE = true // import.meta.env.DEV
+
+// ENABLE_OFFLINE_BIBLE: Cache Bible chapter HTML in IndexedDB for offline access.
+// When false, all Bible text is fetched live from api.bible on every request.
+export const ENABLE_OFFLINE_BIBLE = true
+
+// ENABLE_API_FALLBACK: When ENABLE_OFFLINE_BIBLE is true but IndexedDB is unavailable
+// (e.g. private browsing, storage quota exceeded), allow serving Bible text directly
+// from the API without caching. When false, show a warning instead.
+export const ENABLE_API_FALLBACK = false

--- a/src/store.js
+++ b/src/store.js
@@ -1,5 +1,13 @@
 import { create } from 'zustand'
 
+const TRANSLATIONS = ['KJV', 'NKJV', 'NIV']
+
+function initialDownloadStatus() {
+  return Object.fromEntries(
+    TRANSLATIONS.map(t => [t, { state: 'idle', progress: 0, downloadedBooks: [], bytes: 0, error: null }])
+  )
+}
+
 const useStore = create((set) => ({
   showAbout: false,
   setShowAbout: (v) => set({ showAbout: v }),
@@ -30,7 +38,18 @@ const useStore = create((set) => ({
   dataError: null,
   setData: ({ categories, meta }) =>
     set({ categories, meta, dataLoaded: true, dataError: null }),
-  setDataError: (err) => set({ dataError: err, dataLoaded: false })
+  setDataError: (err) => set({ dataError: err, dataLoaded: false }),
+
+  // Per-translation offline download status
+  // state: 'idle' | 'checking' | 'downloading' | 'complete' | 'error'
+  bibleDownloadStatus: initialDownloadStatus(),
+  setBibleDownloadStatus: (translation, patch) =>
+    set(state => ({
+      bibleDownloadStatus: {
+        ...state.bibleDownloadStatus,
+        [translation]: { ...state.bibleDownloadStatus[translation], ...patch }
+      }
+    })),
 }))
 
 export default useStore

--- a/src/store.js
+++ b/src/store.js
@@ -18,7 +18,7 @@ const useStore = create((set) => ({
     set({ bibleFontSize: size })
   },
 
-  bibleTranslation: localStorage.getItem('bibleTranslation') ?? 'KJV',
+  bibleTranslation: localStorage.getItem('bibleTranslation') ?? 'NKJV',
   bibleBrowseBook: null,
   bibleBrowseChapter: 1,
   setBibleTranslation: (translation) => {

--- a/src/styles/bible-viewer.css
+++ b/src/styles/bible-viewer.css
@@ -226,3 +226,44 @@
 }
 .bible-loading-dots span:nth-child(2) { animation-delay: 0.2s; }
 .bible-loading-dots span:nth-child(3) { animation-delay: 0.4s; }
+
+/* ── Offline download banner ── */
+
+.bible-download-banner {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  padding: 6px 16px 8px;
+  background: var(--color-accent-light);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.bible-download-banner__text {
+  font-size: var(--text-xs);
+  color: var(--color-accent);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.bible-download-progress {
+  height: 3px;
+  background: var(--color-border);
+  border-radius: var(--radius-pill);
+  overflow: hidden;
+}
+
+.bible-download-progress__fill {
+  height: 100%;
+  background: var(--color-accent-mid);
+  border-radius: var(--radius-pill);
+  transition: width 0.3s ease;
+}
+
+/* ── Offline / load error state in chapter segment ── */
+
+.bible-offline-warning {
+  padding: 10px 16px 16px;
+  font-size: var(--text-sm);
+  color: var(--color-muted);
+  font-style: italic;
+}


### PR DESCRIPTION
- Add BibleOfflineStore (IndexedDB) storing raw HTML keyed by
  translation:book:chapter; 3-concurrent fetch with retry backoff
- ApiBibleClient now checks IDB first; on miss fetches from API and
  caches the raw HTML; OfflineOnlyError thrown only when IDB is
  unavailable and ENABLE_API_FALLBACK is false
- Auto-trigger on BibleViewer open: derives catalog books from loaded
  teachings, checks which are missing, downloads them in background
- BibleDownloadBanner shows inline progress (checking / X%) in both
  BiblePanel and BibleDrawer during active downloads
- BibleBrowser gracefully renders offline warning for OfflineOnlyError
- DownloadManager in Settings: per-translation status, download, delete,
  retry; syncs Zustand from IDB on first render
- Two new feature flags: ENABLE_OFFLINE_BIBLE (true), ENABLE_API_FALLBACK (false)

https://claude.ai/code/session_011Lv7j3cwgYDWPJ5HZkmX4R