### PR TITLE
Remove duplicate divorce/fornication teaching from Cat 13.3

### DIFF
--- a/catalog_builds/engine/REVISION.md
+++ b/catalog_builds/engine/REVISION.md
@@ -1,5 +1,6 @@
 ## Table of Contents
 
+- [v1.8 — May 25, 2026](#v18--may-25-2026)
 - [v1.7 — May 17, 2026](#v17--may-17-2026)
 - [v1.6 — May 10, 2026](#v16--may-10-2026)
 - [v1.5 — May 9, 2026](#v15--may-9-2026)
@@ -15,6 +16,29 @@ Tracks all structural changes to `public/teachings.json` by version and date.
 **Format:** Each version entry records the date, catalog stats at the time of writing, and all structural changes made since the previous version. Minor wording edits to `text` or `quote` fields do not require a version bump; structural changes (adds, deletes, moves, renames, splits, merges) do.
 
 <!-- Add new versions above this line -->
+
+## v1.8 — May 25, 2026
+
+| Stat | Count |
+|---|---|
+| Categories | 30 |
+| Subcategories | 117 |
+| Teachings | 644 |
+| Parables | 35 |
+
+### Delete: Remove duplicate divorce/fornication teaching from Cat 13.3
+
+Removed teaching **13.3.3** from **13.3 The Antitheses — "You Have Heard… But I Say to You"** as a duplicate of **18.1.1** in **18.1 Marriage and Divorce**.
+
+**Reason:** Both teachings covered the same declaration (Matt 5:31–32, Matt 19:3–9, Mark 10:2–12, Luke 16:18) about divorce causing adultery. The Antitheses subcategory entry (13.3.3) was a contextual placement of a Family teaching; 18.1.1 in Marriage and Family is the authoritative home for this content. The Family category entry's broader verse ranges (Matt 5:31–32, Matt 19:3–9, Mark 10:2–12) were merged into 18.1.1, which previously held narrower slices (Matt 5:32, Matt 19:9, Mark 10:11–12).
+
+**Deleted:** `13.3.3` — "Jesus says that whoever puts away his wife, except for the cause of fornication, causes her to commit adultery..." (Matt 5:31–32, Matt 19:3–9, Mark 10:2–12, Luke 16:18)
+
+**Updated:** `18.1.1` — expanded references: Matt 5:32 → Matt 5:31–32; Matt 19:9 → Matt 19:3–9; Mark 10:11–12 → Mark 10:2–12
+
+**Net delta:** Cat 13.3: 5 → 4 teachings; Teachings: 645 → 644
+
+---
 
 ## v1.7 — May 17, 2026
 

--- a/catalog_builds/engine/catalog_stats.md
+++ b/catalog_builds/engine/catalog_stats.md
@@ -11,7 +11,7 @@
 | Version | 1.7 |
 | Categories | 30 |
 | Subcategories | 117 |
-| Teachings | 645 |
+| Teachings | 644 |
 | Tagged parables | 35 |
 | NT books covered | Matt, Mark, Luke, John, Acts, 1Cor, 2Cor, Rev |
 
@@ -94,6 +94,7 @@ Also bump `meta.version` in `public/teachings.json` to match the new REVISION.md
 
 | Version | Date | Categories | Subcategories | Teachings | Parables |
 |---|---|---|---|---|---|
+| v1.8 | May 25, 2026 | 30 | 117 | 644 | 35 |
 | v1.7 | May 24, 2026 | 30 | 117 | 645 | 35 |
 | v1.6 | May 10, 2026 | 31 | 117 | 647 | 35 |
 | v1.5 | May 9, 2026 | 31 | 117 | 652 | 35 |

--- a/public/teachings.json
+++ b/public/teachings.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "version": "1.7",
+    "version": "1.8",
     "title": "Jesus Says Data Catalog",
     "subtitle": "A Comprehensive Categorization of His Words as Recorded in the New Testament",
     "totalCategories": 30,
@@ -9696,68 +9696,6 @@
             },
             {
               "id": "13.3.3",
-              "uid": "5396f7c3-d7e8-4c0f-91ab-4e998ec58995",
-              "text": "Jesus says that whoever puts away his wife, except for the cause of fornication, causes her to commit adultery, and whoever marries her who is divorced commits adultery.",
-              "quote": "It hath been said, Whosoever shall put away his wife, let him give her a writing of divorcement: But I say unto you, That whosoever shall put away his wife, saving for the cause of fornication, causeth her to commit adultery: and whosoever shall marry her that is divorced committeth adultery.",
-              "title": "Divorce Except for Fornication Causes Adultery",
-              "tags": [],
-              "references": [
-                {
-                  "label": "Matt 5:31–32",
-                  "book": "Matthew",
-                  "bookAbbr": "Matt",
-                  "chapter": 5,
-                  "ranges": [
-                    [
-                      31,
-                      32
-                    ]
-                  ],
-                  "isPrimary": true
-                },
-                {
-                  "label": "Matt 19:3–9",
-                  "book": "Matthew",
-                  "bookAbbr": "Matt",
-                  "chapter": 19,
-                  "ranges": [
-                    [
-                      3,
-                      9
-                    ]
-                  ],
-                  "isPrimary": false
-                },
-                {
-                  "label": "Mark 10:2–12",
-                  "book": "Mark",
-                  "bookAbbr": "Mark",
-                  "chapter": 10,
-                  "ranges": [
-                    [
-                      2,
-                      12
-                    ]
-                  ],
-                  "isPrimary": false
-                },
-                {
-                  "label": "Luke 16:18",
-                  "book": "Luke",
-                  "bookAbbr": "Luke",
-                  "chapter": 16,
-                  "ranges": [
-                    [
-                      18,
-                      18
-                    ]
-                  ],
-                  "isPrimary": false
-                }
-              ]
-            },
-            {
-              "id": "13.3.4",
               "uid": "896abb2b-0835-4628-b42a-f79d01da97e0",
               "text": "Jesus charges his hearers not to swear at all, neither by heaven nor earth nor Jerusalem nor their head. Let their yes be yes and their no be no, for whatever is more comes of evil.",
               "quote": "¶ Again, ye have heard that it hath been said by them of old time, Thou shalt not forswear thyself, but shalt perform unto the Lord thine oaths: But I say unto you, Swear not at all; neither by heaven; for it is God’s throne: Nor by the earth; for it is his footstool: neither by Jerusalem; for it is the city of the great King. Neither shalt thou swear by thy head, because thou canst not make one hair white or black. But let your communication be, Yea, yea; Nay, nay: for whatsoever is more than these cometh of evil.",
@@ -9780,7 +9718,7 @@
               ]
             },
             {
-              "id": "13.3.5",
+              "id": "13.3.4",
               "uid": "8ca2fd33-1a27-41ed-9b95-dbc6d92d3e69",
               "text": "Jesus teaches his hearers not to resist evil but to turn the other cheek and give their cloak to whoever sues for their coat. He charges them to go two miles with whoever compels them one, and to give to whoever asks.",
               "quote": "¶ Ye have heard that it hath been said, An eye for an eye, and a tooth for a tooth: But I say unto you, That ye resist not evil: but whosoever shall smite thee on thy right cheek, turn to him the other also. And if any man will sue thee at the law, and take away thy coat, let him have thy cloke also. And whosoever shall compel thee to go a mile, go with him twain. Give to him that asketh thee, and from him that would borrow of thee turn not thou away.",
@@ -11907,39 +11845,39 @@
               "tags": [],
               "references": [
                 {
-                  "label": "Matt 5:32",
+                  "label": "Matt 5:31–32",
                   "book": "Matthew",
                   "bookAbbr": "Matt",
                   "chapter": 5,
                   "ranges": [
                     [
-                      32,
+                      31,
                       32
                     ]
                   ],
                   "isPrimary": true
                 },
                 {
-                  "label": "Matt 19:9",
+                  "label": "Matt 19:3–9",
                   "book": "Matthew",
                   "bookAbbr": "Matt",
                   "chapter": 19,
                   "ranges": [
                     [
-                      9,
+                      3,
                       9
                     ]
                   ],
                   "isPrimary": false
                 },
                 {
-                  "label": "Mark 10:11–12",
+                  "label": "Mark 10:2–12",
                   "book": "Mark",
                   "bookAbbr": "Mark",
                   "chapter": 10,
                   "ranges": [
                     [
-                      11,
+                      2,
                       12
                     ]
                   ],


### PR DESCRIPTION
Teaching 13.3.3 in Righteousness & Ethics (Antitheses) duplicated 18.1.1
in Marriage and Family. Removed the Antitheses entry and expanded 18.1.1
references to cover the broader verse ranges: Matt 5:31–32 (was v32 only),
Matt 19:3–9 (was v9 only), Mark 10:2–12 (was v11–12 only). Bumps to v1.8.

https://claude.ai/code/session_01NMdTqRYZw7NAfmS9jSjAaM