### PR TITLE
Fix John 7:24 misclassification — fold into its own Sabbath discourse

### DIFF
--- a/catalog_builds/engine/REVISION.md
+++ b/catalog_builds/engine/REVISION.md
@@ -1,5 +1,6 @@
 ## Table of Contents
 
+- [v1.10 — June 17, 2026](#v110--june-17-2026)
 - [v1.9.1 — June 17, 2026](#v191--june-17-2026)
 - [v1.9 — June 6, 2026](#v19--june-6-2026)
 - [v1.8 — May 25, 2026](#v18--may-25-2026)
@@ -21,6 +22,25 @@ Tracks all changes to `public/teachings.json` by version and date.
 - **PATCH** (`X.Y.Z`) — any other edit that does not change composition: `text`, `quote`, `title`, `tags`, or `references` edits on an existing teaching.
 
 <!-- Add new versions above this line -->
+
+## v1.10 — June 17, 2026
+
+| Stat | Count |
+|---|---|
+| Categories | 30 |
+| Subcategories | 117 |
+| Teachings | 645 |
+| Parables | 35 |
+
+### Rename: Subcategory 13.6 "The Golden Rule and Two Ways" → "The Golden Rule"
+
+**Reason:** v1.9.1 relocated "The Wise and Foolish Builders" out of 13.6 into 6.4 (see below), leaving 13.6 with a single teaching — "Do Unto Others as You Would Have Them Do" (the Golden Rule, Matt 7:12). The "Two Ways" half of the title no longer described any content in the subcategory, so the title was narrowed to match its actual scope.
+
+**Updated:** `13.6` — `title` changed from "The Golden Rule and Two Ways" to "The Golden Rule." IDs and slugs unaffected.
+
+**Net delta:** No composition change — Teachings: 645 → 645
+
+---
 
 ## v1.9.1 — June 17, 2026
 

--- a/catalog_builds/engine/REVISION.md
+++ b/catalog_builds/engine/REVISION.md
@@ -43,6 +43,14 @@ John 7:21–23 — the unbroken lead-in to v.24 within the same uninterrupted st
 
 **Net delta:** No composition change — Teachings: 645 → 645
 
+### Fix: Relocate The Wise and Foolish Builders out of Righteousness and Ethics
+
+**Reason:** Teaching "The Wise and Foolish Builders" (Matt 7:24–27; Luke 6:47–49) was filed in Cat 13's *The Golden Rule and Two Ways* (13.6), but its point isn't an ethical instruction toward others — it's about the consequence of hearing-versus-doing Jesus's words. That is exactly the theme of *The Narrow Way* (6.4) in Cat 6 (Salvation and Eternal Life), which already holds "Obedience Enters the Kingdom, Not Words Alone" (Matt 7:21–23) — the verses immediately preceding this parable in the same Sermon on the Mount conclusion, opened by "Therefore." Per `CLASSIFICATION_RULES.md` Cat 4/6's "many overlap and should be cross-listed" tie-breaker for entry-into-life sayings, this parable belongs alongside its discourse neighbor in 6.4, not in Cat 13's ethics-toward-others scope.
+
+**Moved:** `13.6.2` → `6.4.3` ("The Wise and Foolish Builders," Matt 7:24–27). Inserted immediately after 6.4.2 (Matt 7:21–23); subsequent 6.4 teachings shifted down one ID. Cat 13.6 now holds a single teaching (13.6.1, "Do Unto Others as You Would Have Them Do").
+
+**Net delta:** No composition change — Cat 13.6: 2 → 1 teaching; Cat 6.4: 4 → 5 teachings; Teachings: 645 → 645
+
 ---
 
 ## v1.9 — June 6, 2026

--- a/catalog_builds/engine/REVISION.md
+++ b/catalog_builds/engine/REVISION.md
@@ -1,5 +1,6 @@
 ## Table of Contents
 
+- [v1.9.1 — June 17, 2026](#v191--june-17-2026)
 - [v1.9 — June 6, 2026](#v19--june-6-2026)
 - [v1.8 — May 25, 2026](#v18--may-25-2026)
 - [v1.7 — May 17, 2026](#v17--may-17-2026)
@@ -20,6 +21,29 @@ Tracks all changes to `public/teachings.json` by version and date.
 - **PATCH** (`X.Y.Z`) — any other edit that does not change composition: `text`, `quote`, `title`, `tags`, or `references` edits on an existing teaching.
 
 <!-- Add new versions above this line -->
+
+## v1.9.1 — June 17, 2026
+
+| Stat | Count |
+|---|---|
+| Categories | 30 |
+| Subcategories | 117 |
+| Teachings | 645 |
+| Parables | 35 |
+
+### Fix: Reattach John 7:24 from a mismatched cross-reference to its own discourse
+
+**Reason:** Teaching **13.5.2** ("Do Not Cast Pearls Before Swine," primary ref Matt 7:6) carried `John 7:24` as a secondary reference. The two passages share no thematic or narrative link — John 7:24 ("Judge not according to the appearance, but judge righteous judgment") is the closing line of Jesus's defense of his Sabbath healing at the Feast of Tabernacles, not a parallel to the Sermon on the Mount's pearls-before-swine saying. Per `CLASSIFICATION_RULES.md` Cat 13's explicit exclusion ("Sabbath teaching → *The Sabbath in Right Perspective* (23.4) when the Pharisaical conflict is the setting"), this verse belongs with the Sabbath-controversy discourse, not Cat 13's *Judging and Discernment* (13.5).
+
+John 7:21–23 — the unbroken lead-in to v.24 within the same uninterrupted statement by Jesus — was already cataloged as **23.4.8** ("Circumcision on the Sabbath — Why Not Healing?"). Rather than splitting one continuous quotation into two teaching entries, v.24 was folded into 23.4.8 as the conclusion of that same discourse.
+
+**Updated:** `13.5.2` — removed the mismatched `John 7:24` secondary reference; now carries only its primary reference, Matt 7:6.
+
+**Updated:** `23.4.8` — primary reference extended `John 7:21–23` → `John 7:21–24`; `quote` and `text` extended to include the righteous-judgment conclusion.
+
+**Net delta:** No composition change — Teachings: 645 → 645
+
+---
 
 ## v1.9 — June 6, 2026
 

--- a/catalog_builds/engine/REVISION.md
+++ b/catalog_builds/engine/REVISION.md
@@ -51,6 +51,14 @@ John 7:21–23 — the unbroken lead-in to v.24 within the same uninterrupted st
 
 **Net delta:** No composition change — Cat 13.6: 2 → 1 teaching; Cat 6.4: 4 → 5 teachings; Teachings: 645 → 645
 
+### Fix: Relocate Jesus Laments over Jerusalem's Refusal out of The Narrow Way
+
+**Reason:** Teaching "Jesus Laments over Jerusalem's Refusal" (Luke 13:32–35) was filed in Cat 6's *The Narrow Way* (6.4), but its content — Jesus's rebuke of Jerusalem for killing its prophets and refusing his repeated gathering — is not about the entry-into-life metaphor that defines 6.4; it's a lament over religious leadership's rejection of God's messengers. The near-verbatim parallel discourse (Matt 23:34–39, "Prophets Sent and Killed — Jerusalem's Lament") is already cataloged at **23.5.6** in Cat 23's *Hypocrisy in Leadership* (23.5). Per `TAXONOMY_STANDARDS.md`'s duplicate-resolution rule, the two are not duplicates (different book and chapter), but they describe the same theological point and should be classified consistently — this teaching belongs alongside its thematic sibling in 23.5, not in 6.4.
+
+**Moved:** `6.4.5` → `23.5.10` ("Jesus Laments over Jerusalem's Refusal," Luke 13:32–35). Inserted between 23.5.9 (Mark 11:33) and the former 23.5.10 (Luke 16:15, now 23.5.11) per book/chapter ordering. Cat 6.4 now holds four teachings.
+
+**Net delta:** No composition change — Cat 6.4: 5 → 4 teachings; Cat 23.5: 12 → 13 teachings; Teachings: 645 → 645
+
 ---
 
 ## v1.9 — June 6, 2026

--- a/catalog_builds/engine/catalog_stats.md
+++ b/catalog_builds/engine/catalog_stats.md
@@ -8,7 +8,7 @@
 
 | Metric | Value |
 |---|---|
-| Version | 1.9 |
+| Version | 1.9.1 |
 | Categories | 30 |
 | Subcategories | 117 |
 | Teachings | 645 |
@@ -94,6 +94,7 @@ Also bump `meta.version` in `public/teachings.json` to match the new REVISION.md
 
 | Version | Date | Categories | Subcategories | Teachings | Parables |
 |---|---|---|---|---|---|
+| v1.9.1 | June 17, 2026 | 30 | 117 | 645 | 35 |
 | v1.9 | June 6, 2026 | 30 | 117 | 645 | 35 |
 | v1.8 | May 25, 2026 | 30 | 117 | 644 | 35 |
 | v1.7 | May 24, 2026 | 30 | 117 | 645 | 35 |

--- a/catalog_builds/engine/catalog_stats.md
+++ b/catalog_builds/engine/catalog_stats.md
@@ -8,7 +8,7 @@
 
 | Metric | Value |
 |---|---|
-| Version | 1.9.1 |
+| Version | 1.10 |
 | Categories | 30 |
 | Subcategories | 117 |
 | Teachings | 645 |
@@ -94,6 +94,7 @@ Also bump `meta.version` in `public/teachings.json` to match the new REVISION.md
 
 | Version | Date | Categories | Subcategories | Teachings | Parables |
 |---|---|---|---|---|---|
+| v1.10 | June 17, 2026 | 30 | 117 | 645 | 35 |
 | v1.9.1 | June 17, 2026 | 30 | 117 | 645 | 35 |
 | v1.9 | June 6, 2026 | 30 | 117 | 645 | 35 |
 | v1.8 | May 25, 2026 | 30 | 117 | 644 | 35 |

--- a/public/teachings.json
+++ b/public/teachings.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "version": "1.9.1",
+    "version": "1.10",
     "title": "Jesus Says Data Catalog",
     "subtitle": "A Comprehensive Categorization of His Words as Recorded in the New Testament",
     "totalCategories": 30,
@@ -9922,7 +9922,7 @@
         {
           "id": "13.6",
           "slug": "cat-13-6",
-          "title": "The Golden Rule and Two Ways",
+          "title": "The Golden Rule",
           "teachings": [
             {
               "id": "13.6.1",

--- a/public/teachings.json
+++ b/public/teachings.json
@@ -1,6 +1,6 @@
 {
   "meta": {
-    "version": "1.9",
+    "version": "1.9.1",
     "title": "Jesus Says Data Catalog",
     "subtitle": "A Comprehensive Categorization of His Words as Recorded in the New Testament",
     "totalCategories": 30,
@@ -9875,19 +9875,6 @@
                     ]
                   ],
                   "isPrimary": true
-                },
-                {
-                  "label": "John 7:24",
-                  "book": "John",
-                  "bookAbbr": "John",
-                  "chapter": 7,
-                  "ranges": [
-                    [
-                      24,
-                      24
-                    ]
-                  ],
-                  "isPrimary": false
                 }
               ]
             },
@@ -15823,20 +15810,20 @@
             {
               "id": "23.4.8",
               "uid": "c4c9b7f3-cfb7-4a26-9fab-8ee55bc34955",
-              "text": "Jesus reasons that since Moses gave them circumcision and they circumcise on the sabbath so the law not be broken, they should not be angry that he has made a man whole on the sabbath.",
-              "quote": "I have done one work, and ye all marvel. Moses therefore gave unto you circumcision; (not because it is of Moses, but of the fathers;) and ye on the sabbath day circumcise a man. If a man on the sabbath day receive circumcision, that the law of Moses should not be broken; are ye angry at me, because I have made a man every whit whole on the sabbath day?",
+              "text": "Jesus reasons that since Moses gave them circumcision and they circumcise on the sabbath so the law not be broken, they should not be angry that he has made a man whole on the sabbath, and instructs them not to judge by appearance but with righteous judgment.",
+              "quote": "I have done one work, and ye all marvel. Moses therefore gave unto you circumcision; (not because it is of Moses, but of the fathers;) and ye on the sabbath day circumcise a man. If a man on the sabbath day receive circumcision, that the law of Moses should not be broken; are ye angry at me, because I have made a man every whit whole on the sabbath day? Judge not according to the appearance, but judge righteous judgment.",
               "title": "Circumcision on the Sabbath — Why Not Healing?",
               "tags": [],
               "references": [
                 {
-                  "label": "John 7:21–23",
+                  "label": "John 7:21–24",
                   "book": "John",
                   "bookAbbr": "John",
                   "chapter": 7,
                   "ranges": [
                     [
                       21,
-                      23
+                      24
                     ]
                   ],
                   "isPrimary": true

--- a/public/teachings.json
+++ b/public/teachings.json
@@ -6556,29 +6556,6 @@
                   "isPrimary": true
                 }
               ]
-            },
-            {
-              "id": "6.4.5",
-              "uid": "a82d2e51-d1d9-4296-9881-e014d717743b",
-              "text": "Jesus calls Herod that fox and says he will continue his work until perfected on the third day. He laments over Jerusalem that kills its prophets, saying how often he longed to gather her children as a hen gathers her brood, but they refused.",
-              "quote": "Go ye, and tell that fox, Behold, I cast out devils, and I do cures to day and to morrow, and the third day I shall be perfected. Nevertheless I must walk to day, and to morrow, and the day following: for it cannot be that a prophet perish out of Jerusalem. O Jerusalem, Jerusalem, which killest the prophets, and stonest them that are sent unto thee; how often would I have gathered thy children together, as a hen doth gather her brood under her wings, and ye would not! Behold, your house is left unto you desolate: and verily I say unto you, Ye shall not see me, until the time come when ye shall say, Blessed is he that cometh in the name of the Lord.",
-              "title": "Jesus Laments over Jerusalem's Refusal",
-              "tags": [],
-              "references": [
-                {
-                  "label": "Luke 13:32–35",
-                  "book": "Luke",
-                  "bookAbbr": "Luke",
-                  "chapter": 13,
-                  "ranges": [
-                    [
-                      32,
-                      35
-                    ]
-                  ],
-                  "isPrimary": true
-                }
-              ]
             }
           ],
           "uid": "5c58ad8f-b499-459c-a99b-cfe5a5b49ad7"
@@ -16129,6 +16106,29 @@
             },
             {
               "id": "23.5.10",
+              "uid": "a82d2e51-d1d9-4296-9881-e014d717743b",
+              "text": "Jesus calls Herod that fox and says he will continue his work until perfected on the third day. He laments over Jerusalem that kills its prophets, saying how often he longed to gather her children as a hen gathers her brood, but they refused.",
+              "quote": "Go ye, and tell that fox, Behold, I cast out devils, and I do cures to day and to morrow, and the third day I shall be perfected. Nevertheless I must walk to day, and to morrow, and the day following: for it cannot be that a prophet perish out of Jerusalem. O Jerusalem, Jerusalem, which killest the prophets, and stonest them that are sent unto thee; how often would I have gathered thy children together, as a hen doth gather her brood under her wings, and ye would not! Behold, your house is left unto you desolate: and verily I say unto you, Ye shall not see me, until the time come when ye shall say, Blessed is he that cometh in the name of the Lord.",
+              "title": "Jesus Laments over Jerusalem's Refusal",
+              "tags": [],
+              "references": [
+                {
+                  "label": "Luke 13:32–35",
+                  "book": "Luke",
+                  "bookAbbr": "Luke",
+                  "chapter": 13,
+                  "ranges": [
+                    [
+                      32,
+                      35
+                    ]
+                  ],
+                  "isPrimary": true
+                }
+              ]
+            },
+            {
+              "id": "23.5.11",
               "uid": "a3367c51-6fb4-429f-9e44-c7d227cc9f96",
               "text": "Jesus tells the Pharisees they justify themselves before men, but God knows their hearts, for what men esteem highly is abomination before God.",
               "quote": "Ye are they which justify yourselves before men; but God knoweth your hearts: for that which is highly esteemed among men is abomination in the sight of God.",
@@ -16151,7 +16151,7 @@
               ]
             },
             {
-              "id": "23.5.11",
+              "id": "23.5.12",
               "uid": "eb533ced-3ab7-4f85-becb-778882ff23d3",
               "text": "Jesus tells the leaders he receives no honor from men but knows they have not the love of God in them, for they receive him not though he comes in his Father's name; he declares that Moses, in whom they trust, accuses them.",
               "quote": "I receive not honour from men. But I know you, that ye have not the love of God in you. I am come in my Father’s name, and ye receive me not: if another shall come in his own name, him ye will receive. How can ye believe, which receive honour one of another, and seek not the honour that cometh from God only? Do not think that I will accuse you to the Father: there is one that accuseth you, even Moses, in whom ye trust.",
@@ -16174,7 +16174,7 @@
               ]
             },
             {
-              "id": "23.5.12",
+              "id": "23.5.13",
               "uid": "413a83a2-3623-4dc9-8eeb-f2bf2c3118f9",
               "text": "Jesus tells the religious leaders that though they are Abraham's seed, they seek to kill him because his word has no place in them, and that they do the deeds of their father the devil — a murderer from the beginning, the father of lies; because Jesus tells them the truth they do not believe him, for he that is of God hears God's words.",
               "quote": "I know that ye are Abraham’s seed; but ye seek to kill me, because my word hath no place in you. I speak that which I have seen with my Father: and ye do that which ye have seen with your father. If ye were Abraham’s children, ye would do the works of Abraham. But now ye seek to kill me, a man that hath told you the truth, which I have heard of God: this did not Abraham. Ye do the deeds of your father. If God were your Father, ye would love me: for I proceeded forth and came from God; neither came I of myself, but he sent me. Why do ye not understand my speech? even because ye cannot hear my word. Ye are of your father the devil, and the lusts of your father ye will do. He was a murderer from the beginning, and abode not in the truth, because there is no truth in him. When he speaketh a lie, he speaketh of his own: for he is a liar, and the father of it. And because I tell you the truth, ye believe me not. Which of you convinceth me of sin? And if I say the truth, why do ye not believe me? He that is of God heareth God’s words: ye therefore hear them not, because ye are not of God.",

--- a/public/teachings.json
+++ b/public/teachings.json
@@ -6498,6 +6498,44 @@
             },
             {
               "id": "6.4.3",
+              "uid": "f590d6ef-cf59-40de-8927-e75b4a02bd9d",
+              "text": "Jesus likens whoever hears his sayings and does them to a wise man who built on rock, which stood when the storms came. Whoever hears but does them not is like a foolish man who built on sand, and great was its fall.",
+              "quote": "¶ Therefore whosoever heareth these sayings of mine, and doeth them, I will liken him unto a wise man, which built his house upon a rock: And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not: for it was founded upon a rock. And every one that heareth these sayings of mine, and doeth them not, shall be likened unto a foolish man, which built his house upon the sand: And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell: and great was the fall of it.",
+              "title": "The Wise and Foolish Builders",
+              "tags": [
+                "parable"
+              ],
+              "references": [
+                {
+                  "label": "Matt 7:24–27",
+                  "book": "Matthew",
+                  "bookAbbr": "Matt",
+                  "chapter": 7,
+                  "ranges": [
+                    [
+                      24,
+                      27
+                    ]
+                  ],
+                  "isPrimary": true
+                },
+                {
+                  "label": "Luke 6:47–49",
+                  "book": "Luke",
+                  "bookAbbr": "Luke",
+                  "chapter": 6,
+                  "ranges": [
+                    [
+                      47,
+                      49
+                    ]
+                  ],
+                  "isPrimary": false
+                }
+              ]
+            },
+            {
+              "id": "6.4.4",
               "uid": "7ca1bd29-8428-4817-938f-6b500d398ff4",
               "text": "Jesus warns that once the master shuts the door, those who knock saying Lord, Lord will hear him answer that he does not know them; though they protest they ate with him and he taught in their streets, he will tell them to depart.",
               "quote": "When once the master of the house is risen up, and hath shut to the door, and ye begin to stand without, and to knock at the door, saying, Lord, Lord, open unto us; and he shall answer and say unto you, I know you not whence ye are: Then shall ye begin to say, We have eaten and drunk in thy presence, and thou hast taught in our streets. But he shall say, I tell you, I know you not whence ye are; depart from me, all ye workers of iniquity.",
@@ -6520,7 +6558,7 @@
               ]
             },
             {
-              "id": "6.4.4",
+              "id": "6.4.5",
               "uid": "a82d2e51-d1d9-4296-9881-e014d717743b",
               "text": "Jesus calls Herod that fox and says he will continue his work until perfected on the third day. He laments over Jerusalem that kills its prophets, saying how often he longed to gather her children as a hen gathers her brood, but they refused.",
               "quote": "Go ye, and tell that fox, Behold, I cast out devils, and I do cures to day and to morrow, and the third day I shall be perfected. Nevertheless I must walk to day, and to morrow, and the day following: for it cannot be that a prophet perish out of Jerusalem. O Jerusalem, Jerusalem, which killest the prophets, and stonest them that are sent unto thee; how often would I have gathered thy children together, as a hen doth gather her brood under her wings, and ye would not! Behold, your house is left unto you desolate: and verily I say unto you, Ye shall not see me, until the time come when ye shall say, Blessed is he that cometh in the name of the Lord.",
@@ -9939,44 +9977,6 @@
                     [
                       31,
                       31
-                    ]
-                  ],
-                  "isPrimary": false
-                }
-              ]
-            },
-            {
-              "id": "13.6.2",
-              "uid": "f590d6ef-cf59-40de-8927-e75b4a02bd9d",
-              "text": "Jesus likens whoever hears his sayings and does them to a wise man who built on rock, which stood when the storms came. Whoever hears but does them not is like a foolish man who built on sand, and great was its fall.",
-              "quote": "¶ Therefore whosoever heareth these sayings of mine, and doeth them, I will liken him unto a wise man, which built his house upon a rock: And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell not: for it was founded upon a rock. And every one that heareth these sayings of mine, and doeth them not, shall be likened unto a foolish man, which built his house upon the sand: And the rain descended, and the floods came, and the winds blew, and beat upon that house; and it fell: and great was the fall of it.",
-              "title": "The Wise and Foolish Builders",
-              "tags": [
-                "parable"
-              ],
-              "references": [
-                {
-                  "label": "Matt 7:24–27",
-                  "book": "Matthew",
-                  "bookAbbr": "Matt",
-                  "chapter": 7,
-                  "ranges": [
-                    [
-                      24,
-                      27
-                    ]
-                  ],
-                  "isPrimary": true
-                },
-                {
-                  "label": "Luke 6:47–49",
-                  "book": "Luke",
-                  "bookAbbr": "Luke",
-                  "chapter": 6,
-                  "ranges": [
-                    [
-                      47,
-                      49
                     ]
                   ],
                   "isPrimary": false


### PR DESCRIPTION
John 7:24 was a mismatched secondary reference on the pearls-before-swine
teaching (13.5.2). It's actually the closing line of the unbroken
Sabbath-healing defense already cataloged at 23.4.8 (John 7:21-23), so it
belongs there instead of Cat 13's Judging and Discernment subcategory.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HYty9wFkKuJQMUhaLdnqyx