### PR TITLE
Fix PWA update delays on iOS by fixing SW update checks and data caching

### DIFF
--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,6 +4,9 @@ import './styles/themes/theme.css'
 import './styles/base.css'
 import './styles/modern-nav.css'
 import App from './App.jsx'
+import { setupSWUpdates } from './registerSW.js'
+
+setupSWUpdates()
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>

--- a/src/registerSW.js
+++ b/src/registerSW.js
@@ -1,0 +1,18 @@
+import { registerSW } from 'virtual:pwa-register'
+
+const UPDATE_CHECK_INTERVAL_MS = 20 * 60 * 1000
+
+export function setupSWUpdates() {
+  registerSW({
+    immediate: true,
+    onRegisteredSW(_swUrl, registration) {
+      if (!registration) return
+
+      setInterval(() => registration.update(), UPDATE_CHECK_INTERVAL_MS)
+
+      document.addEventListener('visibilitychange', () => {
+        if (document.visibilityState === 'visible') registration.update()
+      })
+    }
+  })
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -45,16 +45,18 @@ export default defineConfig({
         ]
       },
       workbox: {
-        globPatterns: ['**/*.{js,css,html,ico,png,svg,json}'],
+        cleanupOutdatedCaches: true,
+        globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
         runtimeCaching: [
           {
             urlPattern: /\/teachings\.json$/,
-            handler: 'CacheFirst',
+            handler: 'NetworkFirst',
             options: {
               cacheName: 'teachings-data',
+              networkTimeoutSeconds: 4,
               expiration: {
                 maxEntries: 1,
-                maxAgeSeconds: 60 * 60 * 24 * 30
+                maxAgeSeconds: 60 * 60 * 24
               }
             }
           },


### PR DESCRIPTION
teachings.json was both precached (revisioned, tied to SW deploy cycle)
and runtime-cached, but precache routes always win route matching, so
the CacheFirst runtime rule with a 30-day max-age was the effective
behavior — catalog updates could be stale for weeks. Exclude it from
the precache glob and switch its runtime strategy to NetworkFirst so
it revalidates on every load instead.

Also wire up registerSW with periodic + visibilitychange-triggered
update() calls, since iOS PWAs reopened from the home screen often
resume a suspended page rather than navigating fresh, so the default
once-per-registration update check could go days without firing.